### PR TITLE
Mint | remove supported asset

### DIFF
--- a/contracts/micro_mint/README.md
+++ b/contracts/micro_mint/README.md
@@ -8,6 +8,7 @@
             * [UpdateConfig](#UpdateConfig)
             * [UpdateMintLimit](#UpdateMintLimit)
             * [RegisterAsset](#RegisterAsset)
+            * [RemoveAsset](#RemoveAsset)
         * Queries
             * [GetNativeAsset](#GetNativeAsset)
             * [GetConfig](#GetConfig)
@@ -31,6 +32,7 @@ Contract responsible to mint a paired snip20 asset
 |peg              | String   |  Symbol to peg to when querying oracle (defaults to native_asset symbol)                                          |  yes     |
 |treasury         | Contract |  Treasury contract                                                                                                |  yes     |
 |oracle           | Contract |  Oracle contract                                                                                                  |  no      |
+|start_epoch      | String   |  The starting epoch                                                                                               |  yes     |
 |epoch_frequency  | String   |  The frequency in which the mint limit resets, if 0 then no limit is enforced                                     |  yes     |
 |epoch_mint_limit | String   |  The limit of uTokens to mint per epoch                                                                           |  yes     |
 ## Admin
@@ -56,8 +58,9 @@ Updates the given values
 #### UpdateMintLimit
 Updates the given values
 ##### Request
-|Name      |Type      |Description                                                                            | optional |
-|----------|----------|---------------------------------------------------------------------------------------|----------|
+|Name             |Type      |Description                                                                            | optional |
+|-----------------|----------|---------------------------------------------------------------------------------------|----------|
+|start_epoch      | String   |  The starting epoch                                                            |  yes     |
 |epoch_frequency  | String   |  The frequency in which the mint limit resets, if 0 then no limit is enforced  |  yes     |
 |epoch_mint_limit | String   |  The limit of uTokens to mint per epoch                                        |  yes     |
 ##### Response
@@ -72,7 +75,6 @@ Updates the given values
 #### RegisterAsset
 Registers a supported asset. The asset must be SNIP-20 compliant since [RegisterReceive](https://github.com/SecretFoundation/SNIPs/blob/master/SNIP-20.md#RegisterReceive) is called.
 
-Note: Will return an error if there's an asset with that address already registered.
 ##### Request
 |Name        |Type    |Description                                                                                                            | optional |
 |------------|--------|-----------------------------------------------------------------------------------------------------------------------|----------|
@@ -81,6 +83,21 @@ Note: Will return an error if there's an asset with that address already registe
 ```json
 {
   "register_asset": {
+    "status": "success"
+  }
+}
+```
+
+#### RemoveAsset
+Remove a registered asset.
+##### Request
+|Name        |Type    |Description                                                                                                            | optional |
+|------------|--------|-----------------------------------------------------------------------------------------------------------------------|----------|
+|address     | String |  The asset to remove's address                                                                                        |  no      |
+##### Response
+```json
+{
+  "remove_asset": {
     "status": "success"
   }
 }

--- a/contracts/micro_mint/src/contract.rs
+++ b/contracts/micro_mint/src/contract.rs
@@ -116,6 +116,9 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
             contract,
             commission,
         } => handle::try_register_asset(deps, &env, &contract, commission),
+        HandleMsg::RemoveAsset {
+            address
+        } => handle::try_remove_asset(deps, &env, address),
         HandleMsg::Receive {
             sender,
             from,

--- a/contracts/micro_mint/src/handle.rs
+++ b/contracts/micro_mint/src/handle.rs
@@ -324,6 +324,35 @@ pub fn try_register_asset<S: Storage, A: Api, Q: Querier>(
     })
 }
 
+pub fn try_remove_asset<S: Storage, A: Api, Q: Querier>(
+    deps: &mut Extern<S, A, Q>,
+    env: &Env,
+    address: HumanAddr
+) -> StdResult<HandleResponse> {
+
+    let address_str = address.to_string();
+
+    // Remove asset from the array
+    asset_list_w(&mut deps.storage).update(|mut state| {
+        state.retain(|value| *value != address_str);
+        Ok(state)
+    })?;
+
+    // Remove supported asset
+    assets_w(&mut deps.storage).remove(&address_str.as_bytes());
+
+    // We wont remove the total burned since we want to keep track of all the burned assets
+
+    Ok(HandleResponse {
+        messages: vec![],
+        log: vec![],
+        data: Some( to_binary(
+            &HandleAnswer::RemoveAsset {
+                status: ResponseStatus::Success }
+        )?
+        )
+    })
+}
 
 pub fn register_receive (
     env: &Env,

--- a/contracts/micro_mint/src/handle.rs
+++ b/contracts/micro_mint/src/handle.rs
@@ -210,6 +210,7 @@ pub fn try_update_config<S: Storage, A: Api, Q: Querier>(
 pub fn try_update_limit<S: Storage, A: Api, Q: Querier>(
     deps: &mut Extern<S, A, Q>,
     env: Env,
+    start_epoch: Option<Uint128>,
     epoch_frequency: Option<Uint128>,
     epoch_limit: Option<Uint128>,
 ) -> StdResult<HandleResponse> {
@@ -238,7 +239,11 @@ pub fn try_update_limit<S: Storage, A: Api, Q: Querier>(
         // Reset next epoch
         if state.frequency == 0 {
             state.next_epoch = 0;
-        } else {
+        }
+        else if let Some(next_epoch) = start_epoch {
+            state.next_epoch = next_epoch.u128() as u64;
+        }
+        else {
             state.next_epoch = env.block.time + state.frequency;
         }
         Ok(state)

--- a/contracts/micro_mint/src/test.rs
+++ b/contracts/micro_mint/src/test.rs
@@ -68,6 +68,7 @@ pub mod tests {
             oracle,
             peg,
             treasury,
+            start_epoch: None,
             epoch_frequency: None,
             epoch_mint_limit: None
         };

--- a/packages/shade_protocol/src/micro_mint.rs
+++ b/packages/shade_protocol/src/micro_mint.rs
@@ -46,6 +46,7 @@ pub struct InitMsg {
     // Both treasury & commission must be set to function
     pub treasury: Option<Contract>,
     // If left blank no limit will be enforced
+    pub start_epoch: Option<Uint128>,
     pub epoch_frequency: Option<Uint128>,
     pub epoch_mint_limit: Option<Uint128>,
 }
@@ -65,6 +66,7 @@ pub enum HandleMsg {
         treasury: Option<Contract>,
     },
     UpdateMintLimit {
+        start_epoch: Option<Uint128>,
         epoch_frequency: Option<Uint128>,
         epoch_limit: Option<Uint128>,
     },

--- a/packages/shade_protocol/src/micro_mint.rs
+++ b/packages/shade_protocol/src/micro_mint.rs
@@ -75,6 +75,9 @@ pub enum HandleMsg {
         // Commission * 100 e.g. 5 == .05 == 5%
         commission: Option<Uint128>,
     },
+    RemoveAsset {
+        address: HumanAddr,
+    },
     Receive {
         sender: HumanAddr,
         from: HumanAddr,
@@ -97,6 +100,7 @@ pub enum HandleAnswer {
     UpdateConfig { status: ResponseStatus },
     UpdateMintLimit { status: ResponseStatus },
     RegisterAsset { status: ResponseStatus },
+    RemoveAsset { status: ResponseStatus },
     Burn { status: ResponseStatus, mint_amount: Uint128 }
 }
 


### PR DESCRIPTION
Can now remove supported assets, this will remove support to use this SNIP20 for minting but will still keep its burned amount information for future use