### PR TITLE
doc2book tool 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,7 @@ members = [
 
   # Mock contracts
   "contracts/mock_band",
+
+  # Tools
+  "tools/doc2book"
 ]

--- a/tools/doc2book/Cargo.toml
+++ b/tools/doc2book/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "doc2book"
+version = "0.1.0"
+edition = "2018"
+
+[[bin]]
+name = "doc2book"
+path = "src/doc2book.rs"
+
+[dev-dependencies]
+pretty_assertions = "1.0.0"

--- a/tools/doc2book/README.md
+++ b/tools/doc2book/README.md
@@ -1,0 +1,59 @@
+# `doc2book`
+A simple tool that scrapes rustdoc comments, `doc2book`-only comments and specified Rust code from a crate's source files 
+and outputs them as a single file (e.g. a Markdown book chapter).
+
+## Usage
+The usage is simple, specify the crate and the output file path
+```
+USAGE: doc2book CRATE_DIR OUT_FILE_PATH
+```
+
+Example from Shade workspace root directory:
+```
+cargo r -p doc2book --release -- packages/shade_protocol doc/book/src/smart_contracts.md
+```
+
+### Comments
+The following comments are scraped:
+- `//! `: [rustdoc][1] crate-level (inner) doc comments    
+- `/// `: [rustdoc][1] code-level (outer) doc comments    
+- `//# `: `doc2book` comments, these will be ignored by rustdoc but picked up by `doc2book`
+
+[1]: https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html
+
+### Code
+The comments `// book_include_code` and `// end_book_include_code` mark a section of code to be copied verbatim and place in a Rust code block (Markdown syntax).
+This code:
+
+```rust
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "snake_case")]
+// book_include_code
+pub struct Contract {
+    /// The address of the contract
+    pub address: HumanAddr,
+    /// The hex encoded hash of the contract code
+    pub code_hash: String,
+}
+// end_book_include_code
+```
+
+Would result in this Markdown section:
+
+~~~
+```rust
+pub struct Contract {
+    /// The address of the contract
+    pub address: HumanAddr,
+    /// The hex encoded hash of the contract code
+    pub code_hash: String,
+}
+```
+~~~
+
+## Limitations
+As the tool is currently very simple it has a few limitations:
+- The crate structure is expected to be one file per module at the same directory level as the lib.rs file.
+- The tool outputs everything as a single file, it could be made to create a 'sub-chapter' file for each module.
+- Due to it creating a single file, the ordering of comments, modules declarations and the code is the order it will appear output file.
+- Adding whitespace between scraped sections needs to be explicit, i.e. an empty comment line needs to be inserted where you want a blank line `//! `.

--- a/tools/doc2book/src/doc2book.rs
+++ b/tools/doc2book/src/doc2book.rs
@@ -1,0 +1,326 @@
+use std::{
+    fs::File,
+    io::{BufRead, BufReader, Error as IoError, Lines, Write},
+};
+
+const USAGE: &str = "USAGE: doc2book CRATE_DIR OUT_FILE_PATH";
+
+type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug)]
+enum Error {
+    CrateSourceDirNotFound(String),
+    LibRsNotFound(String),
+    ModuleSourceNotFound(String),
+    Io(IoError),
+}
+
+impl From<IoError> for Error {
+    fn from(err: IoError) -> Self {
+        Self::Io(err)
+    }
+}
+
+// source reading interface
+trait ReadSource {
+    type Src: BufRead;
+
+    fn lib_rs_path(&self) -> &str;
+
+    fn module_path_from_name(&self, module: &str) -> String;
+
+    fn lines_from_path(&self, src_path: &str) -> Result<Lines<Self::Src>>;
+}
+
+// source reading implementor for crates
+struct CrateSource {
+    crate_src_dir: String,
+    lib_rs_path: String,
+}
+
+impl CrateSource {
+    // ensure the crate is valid,
+    // i.e. it's src directory exists and contains a lib.rs file
+    fn new(crate_dir: &str) -> Result<CrateSource> {
+        let crate_src_dir = format!("{}/src", crate_dir);
+        let lib_rs_path = format!("{}/lib.rs", crate_src_dir);
+
+        if std::fs::metadata(&crate_src_dir).is_err() {
+            return Err(Error::CrateSourceDirNotFound(crate_src_dir));
+        }
+
+        if std::fs::metadata(&lib_rs_path).is_err() {
+            return Err(Error::LibRsNotFound(lib_rs_path));
+        }
+
+        Ok(CrateSource {
+            crate_src_dir,
+            lib_rs_path,
+        })
+    }
+}
+
+impl ReadSource for CrateSource {
+    type Src = BufReader<File>;
+
+    fn lib_rs_path(&self) -> &str {
+        &self.lib_rs_path
+    }
+
+    fn module_path_from_name(&self, module: &str) -> String {
+        format!("{}/{}.rs", self.crate_src_dir, module)
+    }
+
+    fn lines_from_path(&self, src_path: &str) -> Result<Lines<Self::Src>> {
+        if std::fs::metadata(src_path).is_err() {
+            return Err(Error::ModuleSourceNotFound(src_path.to_string()));
+        }
+
+        let file = File::open(src_path)?;
+        let lines = BufReader::new(file).lines();
+
+        Ok(lines)
+    }
+}
+
+struct Output {
+    output: Vec<u8>,
+}
+
+impl Output {
+    fn new() -> Output {
+        // allocate a decent chunk of memory at the start
+        let output = Vec::with_capacity(1_000_000_000);
+        Output { output }
+    }
+
+    fn push_line(&mut self, line: &str) {
+        writeln!(&mut self.output, "{}", line).unwrap();
+    }
+
+    fn write_into(&self, w: &mut dyn Write) -> Result<()> {
+        w.write_all(&self.output)?;
+        Ok(())
+    }
+}
+
+fn parse_args() -> Option<(String, String)> {
+    let mut args = std::env::args().skip(1);
+    let crate_dir = args.next()?;
+    let out_path = args.next()?;
+    Some((crate_dir, out_path))
+}
+
+fn find_doc_comment(line: &str) -> Option<&str> {
+    line.strip_prefix("//! ")
+        .or_else(|| line.strip_prefix("//# "))
+        .or_else(|| line.strip_prefix("/// "))
+}
+
+// scrape from code between pragmas and each type of doc comment
+fn process_module<I>(input: &I, output: &mut Output, module_name: &str) -> Result<()>
+where
+    I: ReadSource,
+{
+    let module_path = input.module_path_from_name(module_name);
+    eprintln!("Processing module file: {}", module_path);
+
+    let mut code_transcribe_enabled = false;
+
+    for line in input.lines_from_path(&module_path)? {
+        let line = line?;
+
+        if line.starts_with("// book_include_code") {
+            output.push_line("```rust");
+            code_transcribe_enabled = true;
+            continue;
+        }
+
+        if line.starts_with("// end_book_include_code") {
+            output.push_line("```");
+            code_transcribe_enabled = false;
+            continue;
+        }
+
+        if code_transcribe_enabled {
+            output.push_line(&line);
+            continue;
+        }
+
+        if let Some(line) = find_doc_comment(&line) {
+            output.push_line(line);
+        }
+    }
+
+    Ok(())
+}
+
+// start with the crate root, lib.rs
+// scrape code comments and with each public module inserted in the order they appear
+fn process_crate<I>(input: I, output: &mut Output) -> Result<()>
+where
+    I: ReadSource,
+{
+    let lib_rs_path = input.lib_rs_path();
+    eprintln!("Processing lib.rs file: {}", lib_rs_path);
+
+    for line in input.lines_from_path(lib_rs_path)? {
+        let line = line?;
+
+        if let Some(doc) = find_doc_comment(&line) {
+            output.push_line(doc);
+            continue;
+        }
+
+        if line.starts_with("pub mod ") && line.ends_with(';') {
+            let module = line
+                .strip_prefix("pub mod ")
+                .unwrap()
+                .strip_suffix(';')
+                .unwrap();
+
+            process_module(&input, output, module)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn main() {
+    let (crate_root_dir, out_path) = match parse_args() {
+        Some(args) => args,
+        _ => return eprintln!("{}", USAGE),
+    };
+
+    let input = match CrateSource::new(&crate_root_dir) {
+        Ok(input) => input,
+        Err(Error::CrateSourceDirNotFound(path)) => {
+            eprintln!(
+                "{} does not exist. Make sure the specified directory is a Rust project.",
+                path
+            );
+            return eprintln!("{}", USAGE);
+        }
+        Err(Error::LibRsNotFound(path)) => {
+            eprintln!("{} not does not exist. The crate must be a library.", path);
+            return eprintln!("{}", USAGE);
+        }
+        Err(err) => panic!("unexpected err: {:?}", err),
+    };
+
+    let mut output = Output::new();
+
+    let result = process_crate(input, &mut output).and_then(|_| {
+        let mut out_file = File::create(out_path)?;
+        output.write_into(&mut out_file)
+    });
+
+    if let Err(err) = result {
+        match err {
+            Error::ModuleSourceNotFound(path) => {
+                eprintln!(
+                    "Processing module file {} failed: file does not exist",
+                    path
+                )
+            }
+            Error::Io(err) => eprintln!("Unexpected I/O Error: {}", err),
+            err => panic!("unexpected err: {:?}", err),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    const LIB_RS: &str = r#"//! # Main Title
+//! Some text
+//! 
+
+pub mod helper_mod;
+
+//# ## Common Types
+//# Some more text
+//# 
+
+pub mod common_types;
+"#;
+
+    const COMMON_TYPES_RS: &str = r#"use some_dep::module;    
+use some_other_dep::module;
+
+//# ### `Contract`
+/// Represents another contract on the network
+/// 
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "snake_case")]
+// book_include_code
+pub struct Contract {
+    /// The address of the contract
+    pub address: HumanAddr,
+    /// The hex encoded hash of the contract code
+    pub code_hash: String,
+}
+// end_book_include_code"#;
+
+    const EXPECTED_OUTPUT: &str = r#"# Main Title
+Some text
+
+## Common Types
+Some more text
+
+### `Contract`
+Represents another contract on the network
+
+```rust
+pub struct Contract {
+    /// The address of the contract
+    pub address: HumanAddr,
+    /// The hex encoded hash of the contract code
+    pub code_hash: String,
+}
+```
+"#;
+
+    struct TestInput;
+
+    impl ReadSource for TestInput {
+        type Src = BufReader<&'static [u8]>;
+
+        fn lib_rs_path(&self) -> &str {
+            "src/lib.rs"
+        }
+
+        fn module_path_from_name(&self, module: &str) -> String {
+            format!("src/{}.rs", module)
+        }
+
+        fn lines_from_path(&self, src_path: &str) -> Result<Lines<Self::Src>> {
+            let s: &'static str = match src_path {
+                "src/lib.rs" => LIB_RS,
+                "src/common_types.rs" => COMMON_TYPES_RS,
+                "src/helper_mod.rs" => "",
+                _ => panic!("Unexpected path: {}", src_path),
+            };
+
+            Ok(BufReader::new(s.as_bytes()).lines())
+        }
+    }
+
+    #[test]
+    fn it_works() {
+        let mut output = Output::new();
+
+        process_crate(TestInput, &mut output).unwrap();
+
+        let mut actual = Vec::new();
+
+        output.write_into(&mut actual).unwrap();
+
+        let actual = String::from_utf8(actual).unwrap();
+
+        assert_eq!(actual, EXPECTED_OUTPUT.to_owned())
+    }
+}


### PR DESCRIPTION
This is a simple tool that scrapes the documentation comments and specified code blocks from a target crate. See `tools/doc2book/README.md` for more info.

It was made with the `packages/shade_protocol` crate in mind. Hopefully this should make it simple to generate the smart contract interface and usage documentation from the source code itself, where it will be easier to keep up to date.

If anyone can think of a better name (please please please) just let me know and I'll update it.