### PR TITLE
Shd stake | rewards distribution

### DIFF
--- a/contracts/staking/src/contract.rs
+++ b/contracts/staking/src/contract.rs
@@ -9,7 +9,8 @@ use shade_protocol::{
 };
 use crate::{
     state::{config_w, unbonding_w, stake_state_w},
-    handle::{try_update_config, try_stake, try_unbond, try_trigger_unbounds, try_vote},
+    handle::{try_update_config, try_stake, try_unbond,
+             try_claim_unbond, try_claim_rewards, try_vote, try_set_viewing_key},
     query
 };
 use secret_toolkit::{snip20::register_receive_msg, utils::HandleCallback};
@@ -69,7 +70,9 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
         } => try_unbond(deps, &env, amount),
         HandleMsg::Vote { proposal_id, votes
         } => try_vote(deps, &env, proposal_id, votes),
-        HandleMsg::TriggerUnbonds { } => try_trigger_unbounds(deps, &env),
+        HandleMsg::ClaimUnbond {} => try_claim_unbond(deps, &env),
+        HandleMsg::ClaimRewards {} => try_claim_rewards(deps, &env),
+        HandleMsg::SetViewingKey { key } => try_set_viewing_key(deps, &env, key),
     }
 }
 
@@ -80,5 +83,9 @@ pub fn query<S: Storage, A: Api, Q: Querier>(
     match msg {
         QueryMsg::Config { } => to_binary(&query::config(deps)?),
         QueryMsg::TotalStaked { } => to_binary(&query::total_staked(deps)?),
+        QueryMsg::TotalUnbonding { start, end
+        } => to_binary(&query::total_unbonding(deps, start, end)?),
+        QueryMsg::UserStake { address, key, time
+        } => to_binary(&query::user_stake(deps, address, key, time)?),
     }
 }

--- a/contracts/staking/src/query.rs
+++ b/contracts/staking/src/query.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{Api, Extern, Querier, StdError, StdResult, Storage, Uint128};
 use shade_protocol::{staking::{QueryMsg, QueryAnswer}, snip20};
-use crate::{state::{config_r, total_staked_r}};
+use crate::{state::{config_r, stake_state_r}};
 
 pub fn config<S: Storage, A: Api, Q: Querier>(
     deps: &Extern<S, A, Q>) -> StdResult<QueryAnswer> {
@@ -14,6 +14,6 @@ pub fn total_staked<S: Storage, A: Api, Q: Querier>(
     deps: &Extern<S, A, Q>) -> StdResult<QueryAnswer> {
 
     Ok(QueryAnswer::TotalStaked {
-        total: total_staked_r(&deps.storage).load()?,
+        total: stake_state_r(&deps.storage).load()?.total_tokens,
     })
 }

--- a/contracts/staking/src/query.rs
+++ b/contracts/staking/src/query.rs
@@ -26,19 +26,11 @@ pub fn total_unbonding<S: Storage, A: Api, Q: Querier>(
     let mut total = Uint128::zero();
     let mut queue = unbonding_r(&deps.storage).load()?;
 
-    let start = match start_limit {
-        None => 0u64,
-        Some(start) => start
-    };
+    let start = start_limit.unwrap_or(0u64);
 
-    let end = match end_limit {
-        None => u64::MAX,
-        Some(end) => end
-    };
+    let end = end_limit.unwrap_or(u64::MAX);
 
-    while !queue.is_empty() {
-        let item = queue.pop().unwrap();
-
+    while let Some(item) = queue.pop() {
         if start <= item.unbond_time && item.unbond_time <= end {
             total += item.amount;
         }

--- a/contracts/staking/src/state.rs
+++ b/contracts/staking/src/state.rs
@@ -1,11 +1,11 @@
 use cosmwasm_std::{Storage, Uint128};
 use cosmwasm_storage::{singleton, singleton_read, ReadonlySingleton, Singleton, bucket, Bucket, bucket_read, ReadonlyBucket};
 
-use shade_protocol::staking::{Config, Unbonding};
+use shade_protocol::staking::{Config, StakeState, Unbonding, UserStakeState};
 use binary_heap_plus::{BinaryHeap, MinComparator};
 
 pub static CONFIG_KEY: &[u8] = b"config";
-pub static TOTAL_STAKED_KEY: &[u8] = b"total_staked";
+pub static STAKE_STATE_KEY: &[u8] = b"stake_state";
 pub static STAKER_KEY: &[u8] = b"staker";
 pub static UNBONDING_KEY: &[u8] = b"unbonding";
 
@@ -17,19 +17,19 @@ pub fn config_r<S: Storage>(storage: &S) -> ReadonlySingleton<S, Config> {
     singleton_read(storage, CONFIG_KEY)
 }
 
-pub fn total_staked_w<S: Storage>(storage: &mut S) -> Singleton<S, Uint128> {
-    singleton(storage, TOTAL_STAKED_KEY)
+pub fn stake_state_w<S: Storage>(storage: &mut S) -> Singleton<S, StakeState> {
+    singleton(storage, STAKE_STATE_KEY)
 }
 
-pub fn total_staked_r<S: Storage>(storage: &S) -> ReadonlySingleton<S, Uint128> {
-    singleton_read(storage, TOTAL_STAKED_KEY)
+pub fn stake_state_r<S: Storage>(storage: &S) -> ReadonlySingleton<S, StakeState> {
+    singleton_read(storage, STAKE_STATE_KEY)
 }
 
-pub fn staker_r<S: Storage>(storage: & S) -> ReadonlyBucket<S, Uint128> {
+pub fn staker_r<S: Storage>(storage: & S) -> ReadonlyBucket<S, UserStakeState> {
     bucket_read(STAKER_KEY, storage)
 }
 
-pub fn staker_w<S: Storage>(storage: &mut S) -> Bucket<S, Uint128> {
+pub fn staker_w<S: Storage>(storage: &mut S) -> Bucket<S, UserStakeState> {
     bucket(STAKER_KEY, storage)
 }
 

--- a/contracts/staking/src/state.rs
+++ b/contracts/staking/src/state.rs
@@ -8,6 +8,8 @@ pub static CONFIG_KEY: &[u8] = b"config";
 pub static STAKE_STATE_KEY: &[u8] = b"stake_state";
 pub static STAKER_KEY: &[u8] = b"staker";
 pub static UNBONDING_KEY: &[u8] = b"unbonding";
+pub static USER_UNBONDING_KEY: &[u8] = b"user_unbonding";
+pub static VIEWKING_KEY: &[u8] = b"viewing_key";
 
 pub fn config_w<S: Storage>(storage: &mut S) -> Singleton<S, Config> {
     singleton(storage, CONFIG_KEY)
@@ -33,10 +35,27 @@ pub fn staker_w<S: Storage>(storage: &mut S) -> Bucket<S, UserStakeState> {
     bucket(STAKER_KEY, storage)
 }
 
+// Ideally these queues will be removed
 pub fn unbonding_w<S: Storage>(storage: &mut S) -> Singleton<S, BinaryHeap<Unbonding, MinComparator>> {
     singleton(storage, UNBONDING_KEY)
 }
 
 pub fn unbonding_r<S: Storage>(storage: &S) -> ReadonlySingleton<S, BinaryHeap<Unbonding, MinComparator>> {
     singleton_read(storage, UNBONDING_KEY)
+}
+
+pub fn user_unbonding_r<S: Storage>(storage: & S) -> ReadonlyBucket<S, BinaryHeap<Unbonding, MinComparator>> {
+    bucket_read(USER_UNBONDING_KEY, storage)
+}
+
+pub fn user_unbonding_w<S: Storage>(storage: &mut S) -> Bucket<S, BinaryHeap<Unbonding, MinComparator>> {
+    bucket(USER_UNBONDING_KEY, storage)
+}
+
+pub fn viewking_key_r<S: Storage>(storage: & S) -> ReadonlyBucket<S, String> {
+    bucket_read(VIEWKING_KEY, storage)
+}
+
+pub fn viewking_key_w<S: Storage>(storage: &mut S) -> Bucket<S, String> {
+    bucket(VIEWKING_KEY, storage)
 }

--- a/contracts/staking/src/test.rs
+++ b/contracts/staking/src/test.rs
@@ -19,17 +19,14 @@ pub mod tests {
 
         // Add the three values in a non order fashion
         let val1 = Unbonding {
-            account: Default::default(),
             amount: Default::default(),
             unbond_time: 0
         };
         let val2 = Unbonding {
-            account: Default::default(),
             amount: Default::default(),
             unbond_time: 1
         };
         let val3 = Unbonding {
-            account: Default::default(),
             amount: Default::default(),
             unbond_time: 2
         };

--- a/contracts/staking/src/test.rs
+++ b/contracts/staking/src/test.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 pub mod tests {
     use binary_heap_plus::{BinaryHeap, MinComparator};
-    use shade_protocol::staking::Unbonding;
-    use cosmwasm_std::Uint128;
-    use crate::handle::stake_weight;
+    use shade_protocol::staking::{StakeState, Unbonding, UserStakeState};
+    use cosmwasm_std::{Decimal, Uint128};
+    use crate::handle::{calculate_shares, calculate_tokens, stake_weight};
 
     #[test]
     fn test_weight_calculation() {
@@ -42,4 +42,126 @@ pub mod tests {
         assert_eq!(1, unbonding_heap.pop().unwrap().unbond_time);
         assert_eq!(2, unbonding_heap.pop().unwrap().unbond_time);
     }
+
+    fn init_user() -> UserStakeState {
+        UserStakeState {
+            shares: Uint128::zero(),
+            tokens_staked: Uint128::zero()
+        }
+    }
+
+    fn stake(state: &mut StakeState, user: &mut UserStakeState, amount: Uint128) -> Uint128 {
+        let shares = calculate_shares(amount, state);
+        state.total_tokens += amount;
+        state.total_shares += shares;
+        user.tokens_staked += amount;
+        user.shares += shares;
+
+        shares
+    }
+
+    fn unbond(state: &mut StakeState, user: &mut UserStakeState, amount: Uint128) -> Uint128 {
+        let shares = calculate_shares(amount, state);
+        state.total_tokens = (state.total_tokens - amount).unwrap();
+        state.total_shares = (state.total_shares - shares).unwrap();
+        user.tokens_staked = (user.tokens_staked - amount).unwrap();
+        user.shares = (user.shares - shares).unwrap();
+
+        shares
+    }
+
+    #[test]
+    fn standard_staking() {
+        let mut state = StakeState {
+            total_shares: Uint128::zero(),
+            total_tokens: Uint128::zero()
+        };
+
+        // User 1 stakes 100
+        let mut u1 = init_user();
+        let u1_stake = Uint128(100);
+        stake(&mut state, &mut u1, u1_stake);
+
+        assert_eq!(u1_stake, calculate_tokens(u1.shares, &state));
+
+        // User 2 stakes 50
+        let mut u2 = init_user();
+        let u2_stake = Uint128(50);
+        stake(&mut state, &mut u2, u2_stake);
+
+        assert_eq!(u1_stake, calculate_tokens(u1.shares, &state));
+        assert_eq!(u2_stake, calculate_tokens(u2.shares, &state));
+
+        // User 3 stakes 35
+        let mut u3 = init_user();
+        let u3_stake = Uint128(35);
+        stake(&mut state, &mut u3, u3_stake);
+
+        assert_eq!(u1_stake, calculate_tokens(u1.shares, &state));
+        assert_eq!(u2_stake, calculate_tokens(u2.shares, &state));
+        assert_eq!(u3_stake, calculate_tokens(u3.shares, &state));
+    }
+
+    #[test]
+    fn unbonding() {
+        let mut state = StakeState {
+            total_shares: Uint128::zero(),
+            total_tokens: Uint128::zero()
+        };
+
+        // User 1 stakes 100
+        let mut u1 = init_user();
+        let u1_stake = Uint128(100);
+        stake(&mut state, &mut u1, u1_stake);
+
+        // User 2 stakes 50
+        let mut u2 = init_user();
+        let u2_stake = Uint128(50);
+        stake(&mut state, &mut u2, u2_stake);
+
+        // User 3 stakes 35
+        let mut u3 = init_user();
+        let u3_stake = Uint128(35);
+        stake(&mut state, &mut u3, u3_stake);
+
+        // User 2 unbonds 25
+        let u2_unbond = Uint128(25);
+        unbond(&mut state, &mut u2, u2_unbond);
+
+        assert_eq!(u1_stake, calculate_tokens(u1.shares, &state));
+        assert_eq!((u2_stake - u2_unbond).unwrap(), calculate_tokens(u2.shares, &state));
+        assert_eq!(u3_stake, calculate_tokens(u3.shares, &state));
+
+    }
+
+    #[test]
+    fn rewards_distribution() {
+        let mut state = StakeState {
+            total_shares: Uint128::zero(),
+            total_tokens: Uint128::zero()
+        };
+
+        // User 1 stakes 100
+        let mut u1 = init_user();
+        let u1_stake = Uint128(100);
+        stake(&mut state, &mut u1, u1_stake);
+
+        // User 2 stakes 50
+        let mut u2 = init_user();
+        let u2_stake = Uint128(50);
+        stake(&mut state, &mut u2, u2_stake);
+
+        // User 3 stakes 50
+        let mut u3 = init_user();
+        let u3_stake = Uint128(50);
+        stake(&mut state, &mut u3, u3_stake);
+
+        // Add a 200 reward, (should double user amounts)
+        state.total_tokens += Uint128(200);
+
+        assert_eq!(u1_stake.multiply_ratio(Uint128(2), Uint128(1)), calculate_tokens(u1.shares, &state));
+        assert_eq!(u2_stake.multiply_ratio(Uint128(2), Uint128(1)), calculate_tokens(u2.shares, &state));
+        assert_eq!(u3_stake.multiply_ratio(Uint128(2), Uint128(1)), calculate_tokens(u3.shares, &state));
+    }
+
 }

--- a/packages/network_integration/src/contract_helpers/stake.rs
+++ b/packages/network_integration/src/contract_helpers/stake.rs
@@ -9,8 +9,10 @@ use secretcli::{cli_types::NetContract,
                 secretcli::{query_contract, test_contract_handle, test_inst_init}};
 use crate::contract_helpers::minter::get_balance;
 use std::{thread, time};
+use std::time::UNIX_EPOCH;
 
-pub fn setup_staker(governance: &NetContract, shade: &Contract, staking_account: String) -> Result<NetContract> {
+pub fn setup_staker(governance: &NetContract, shade: &Contract,
+                    staking_account: String) -> Result<NetContract> {
     let staker = init_contract(&governance, "staking".to_string(),
                                "../../compiled/staking.wasm.gz",
                                staking::InitMsg{
@@ -41,6 +43,14 @@ pub fn setup_staker(governance: &NetContract, shade: &Contract, staking_account:
     let unbond_amount = Uint128(2000000);
     let balance_after_stake = (original_balance - stake_amount).unwrap();
 
+    // Make a query key
+    {
+        let msg = staking::HandleMsg::SetViewingKey { key: "password".to_string() };
+
+        test_contract_handle(&msg, &staker, ACCOUNT_KEY, Some(GAS),
+                             Some("test"), None)?;
+    }
+
     // Stake some Shade on it
     {
         let msg = snip20::HandleMsg::Send {
@@ -58,6 +68,10 @@ pub fn setup_staker(governance: &NetContract, shade: &Contract, staking_account:
     // Check total stake
     assert_eq!(get_total_staked(&staker), stake_amount);
 
+    // Check user stake
+    assert_eq!(get_user_stake(&staker, staking_account.clone(),
+                              "password".to_string()).staked, stake_amount);
+
     // Query total Shade now
     assert_eq!(balance_after_stake, get_balance(&shade_net,
                                                  staking_account.clone()));
@@ -74,28 +88,40 @@ pub fn setup_staker(governance: &NetContract, shade: &Contract, staking_account:
     // Check if unstaking
     assert_eq!(get_total_staked(&staker), (stake_amount - unbond_amount).unwrap());
 
+    // Check if user unstaking
+    {
+        let user_stake = get_user_stake(&staker, staking_account.clone(),
+                                        "password".to_string());
+
+        assert_eq!(user_stake.staked, (stake_amount - unbond_amount).unwrap());
+        assert_eq!(user_stake.unbonding, unbond_amount);
+    }
+
     print_header("Testing unbonding time");
     // User triggers but receives nothing
     {
-        let msg = staking::HandleMsg::TriggerUnbonds {};
+        let msg = staking::HandleMsg::ClaimUnbond {};
 
         test_contract_handle(&msg, &staker, ACCOUNT_KEY, Some(GAS),
                              Some("test"), None)?;
     }
 
     // Query total Shade now
-    {
-        assert_eq!(balance_after_stake, get_balance(&shade_net,
-                                                     staking_account.clone()));
-    }
+
+    assert_eq!(balance_after_stake, get_balance(&shade_net,
+                                                 staking_account.clone()));
 
     // Wait unbonding time
     thread::sleep(time::Duration::from_secs(180));
 
+    // Check if unbonded
+    assert_eq!(get_user_stake(&staker, staking_account.clone(),
+                              "password".to_string()).unbonded, unbond_amount);
+
     print_header("Testing unbonding asset release");
     // User triggers and receives something
     {
-        let msg = staking::HandleMsg::TriggerUnbonds {};
+        let msg = staking::HandleMsg::ClaimUnbond {};
 
         test_contract_handle(&msg, &staker, ACCOUNT_KEY, Some(GAS),
                              Some("test"), None)?;
@@ -117,5 +143,34 @@ pub fn get_total_staked(staker: &NetContract) -> Uint128 {
         return total
     }
 
-    Uint128(0)
+    Uint128::zero()
+}
+
+pub struct TestUserStake {
+    pub staked: Uint128,
+    pub pending_rewards: Uint128,
+    pub unbonding: Uint128,
+    pub unbonded: Uint128
+}
+
+pub fn get_user_stake(staker: &NetContract, address: String, key: String) -> TestUserStake {
+    let msg = staking::QueryMsg::UserStake { address: HumanAddr::from(address), key,
+        time: time::SystemTime::now().duration_since(UNIX_EPOCH).expect("").as_secs() };
+
+    let query: staking::QueryAnswer = query_contract(staker, &msg).unwrap();
+
+    if let staking::QueryAnswer::UserStake { staked, pending_rewards,
+        unbonding, unbonded } = query {
+        return TestUserStake {
+            staked, pending_rewards, unbonding, unbonded
+        }
+    }
+
+
+    TestUserStake {
+        staked: Uint128::zero(),
+        pending_rewards: Uint128::zero(),
+        unbonding: Uint128::zero(),
+        unbonded: Uint128::zero()
+    }
 }

--- a/packages/shade_protocol/src/staking.rs
+++ b/packages/shade_protocol/src/staking.rs
@@ -21,6 +21,21 @@ pub struct Config {
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
+pub struct StakeState{
+    pub total_shares: Uint128,
+    pub total_tokens: Uint128,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct UserStakeState{
+    pub shares: Uint128,
+    // This is used to derive the actual value to recover
+    pub tokens_staked: Uint128,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
 pub struct Unbonding {
     pub account: HumanAddr,
     pub amount: Uint128,
@@ -58,8 +73,6 @@ pub enum HandleMsg {
     Unbond { amount: Uint128 },
     // While secure querying is resolved
     Vote { proposal_id: Uint128, votes: Vec<UserVote> },
-    GetStaker { account: HumanAddr },
-    GetStakers { accounts: Vec<HumanAddr> },
     TriggerUnbonds {},
 }
 
@@ -74,8 +87,6 @@ pub enum HandleAnswer {
     Stake { status: ResponseStatus },
     Unbond { status: ResponseStatus },
     Vote { status: ResponseStatus },
-    GetStaker { status: ResponseStatus, stake: Uint128 },
-    GetStakers { status: ResponseStatus, stake: Vec<Uint128> },
     TriggerUnbonds { status: ResponseStatus },
 }
 

--- a/packages/shade_protocol/src/staking.rs
+++ b/packages/shade_protocol/src/staking.rs
@@ -37,7 +37,6 @@ pub struct UserStakeState{
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct Unbonding {
-    pub account: HumanAddr,
     pub amount: Uint128,
     pub unbond_time: u64,
 }
@@ -73,7 +72,9 @@ pub enum HandleMsg {
     Unbond { amount: Uint128 },
     // While secure querying is resolved
     Vote { proposal_id: Uint128, votes: Vec<UserVote> },
-    TriggerUnbonds {},
+    ClaimUnbond {},
+    ClaimRewards {},
+    SetViewingKey { key: String },
 }
 
 impl HandleCallback for HandleMsg {
@@ -87,7 +88,9 @@ pub enum HandleAnswer {
     Stake { status: ResponseStatus },
     Unbond { status: ResponseStatus },
     Vote { status: ResponseStatus },
-    TriggerUnbonds { status: ResponseStatus },
+    ClaimUnbond { status: ResponseStatus },
+    ClaimRewards { status: ResponseStatus },
+    SetViewingKey { status: ResponseStatus }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -95,6 +98,8 @@ pub enum HandleAnswer {
 pub enum QueryMsg {
     Config {},
     TotalStaked {},
+    TotalUnbonding { start: Option<u64>, end: Option<u64> },
+    UserStake { address: HumanAddr, key: String, time: u64},
 }
 
 impl Query for QueryMsg {
@@ -106,4 +111,6 @@ impl Query for QueryMsg {
 pub enum QueryAnswer {
     Config { config: Config },
     TotalStaked { total: Uint128 },
+    TotalUnbonding { total: Uint128 },
+    UserStake { staked: Uint128, pending_rewards: Uint128, unbonding: Uint128, unbonded: Uint128 },
 }


### PR DESCRIPTION
Added an efficient way to distribute value across stakers by using the staking model found in Cosmos SDK.
There are now separate unbonding queues per users so they can query their values efficiently. The old unbonding now exists for when we implement treasury rewards distribution.
To allow users to query their stake information, a very simple viewing key system was implemented