### PR TITLE
Automaticaly generate contract schemas in release mode

### DIFF
--- a/contracts/airdrop/Cargo.toml
+++ b/contracts/airdrop/Cargo.toml
@@ -46,3 +46,7 @@ serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 snafu = { version = "0.6.3" }
 mockall = "0.10.2"
 mockall_double = "0.2.0"
+
+[build-dependencies]
+cosmwasm-schema = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
+shade-protocol = { version = "0.1.0", path = "../../packages/shade_protocol" }

--- a/contracts/airdrop/build.rs
+++ b/contracts/airdrop/build.rs
@@ -1,0 +1,30 @@
+use std::path::PathBuf;
+
+use cosmwasm_schema::{export_schema, schema_for};
+use shade_protocol::airdrop::{HandleAnswer, HandleMsg, InitMsg, QueryAnswer, QueryMsg};
+
+fn main() {
+    // only generate schemas when building in release mode
+    if cfg!(debug_assertions) {
+        return;
+    }
+
+    let package_dir = env!("CARGO_MANIFEST_DIR");
+    let schema_dir = format!("{}/schema", package_dir);
+
+    if std::fs::metadata(&schema_dir).is_ok() {
+        // if the schemas already exist, only regenerate if the package has changed
+        println!("cargo:rerun-if-changed=../../packages/shade_protocol/src");
+        std::fs::remove_dir_all(&schema_dir).expect("remove stale schemas");
+    }
+
+    std::fs::create_dir(&schema_dir).expect("create schema directory");
+
+    let schema_dir = PathBuf::from(schema_dir);
+
+    export_schema(&schema_for!(InitMsg), &schema_dir);
+    export_schema(&schema_for!(HandleMsg), &schema_dir);
+    export_schema(&schema_for!(HandleAnswer), &schema_dir);
+    export_schema(&schema_for!(QueryMsg), &schema_dir);
+    export_schema(&schema_for!(QueryAnswer), &schema_dir);
+}

--- a/contracts/governance/Cargo.toml
+++ b/contracts/governance/Cargo.toml
@@ -44,3 +44,7 @@ serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 snafu = { version = "0.6.3" }
 mockall = "0.10.2"
 mockall_double = "0.2.0"
+
+[build-dependencies]
+cosmwasm-schema = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
+shade-protocol = { version = "0.1.0", path = "../../packages/shade_protocol" }

--- a/contracts/governance/build.rs
+++ b/contracts/governance/build.rs
@@ -1,0 +1,30 @@
+use std::path::PathBuf;
+
+use cosmwasm_schema::{export_schema, schema_for};
+use shade_protocol::governance::{HandleAnswer, HandleMsg, InitMsg, QueryAnswer, QueryMsg};
+
+fn main() {
+    // only generate schemas when building in release mode
+    if cfg!(debug_assertions) {
+        return;
+    }
+
+    let package_dir = env!("CARGO_MANIFEST_DIR");
+    let schema_dir = format!("{}/schema", package_dir);
+
+    if std::fs::metadata(&schema_dir).is_ok() {
+        // if the schemas already exist, only regenerate if the package has changed
+        println!("cargo:rerun-if-changed=../../packages/shade_protocol/src");
+        std::fs::remove_dir_all(&schema_dir).expect("remove stale schemas");
+    }
+
+    std::fs::create_dir(&schema_dir).expect("create schema directory");
+
+    let schema_dir = PathBuf::from(schema_dir);
+
+    export_schema(&schema_for!(InitMsg), &schema_dir);
+    export_schema(&schema_for!(HandleMsg), &schema_dir);
+    export_schema(&schema_for!(HandleAnswer), &schema_dir);
+    export_schema(&schema_for!(QueryMsg), &schema_dir);
+    export_schema(&schema_for!(QueryAnswer), &schema_dir);
+}

--- a/contracts/initializer/Cargo.toml
+++ b/contracts/initializer/Cargo.toml
@@ -42,3 +42,7 @@ shade-protocol = { version = "0.1.0", path = "../../packages/shade_protocol" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 snafu = { version = "0.6.3" }
+
+[build-dependencies]
+cosmwasm-schema = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
+shade-protocol = { version = "0.1.0", path = "../../packages/shade_protocol" }

--- a/contracts/initializer/build.rs
+++ b/contracts/initializer/build.rs
@@ -1,0 +1,29 @@
+use std::path::PathBuf;
+
+use cosmwasm_schema::{export_schema, schema_for};
+use shade_protocol::initializer::{HandleMsg, InitMsg, QueryAnswer, QueryMsg};
+
+fn main() {
+    // only generate schemas when building in release mode
+    if cfg!(debug_assertions) {
+        return;
+    }
+
+    let package_dir = env!("CARGO_MANIFEST_DIR");
+    let schema_dir = format!("{}/schema", package_dir);
+
+    if std::fs::metadata(&schema_dir).is_ok() {
+        // if the schemas already exist, only regenerate if the package has changed
+        println!("cargo:rerun-if-changed=../../packages/shade_protocol/src");
+        std::fs::remove_dir_all(&schema_dir).expect("remove stale schemas");
+    }
+
+    std::fs::create_dir(&schema_dir).expect("create schema directory");
+
+    let schema_dir = PathBuf::from(schema_dir);
+
+    export_schema(&schema_for!(InitMsg), &schema_dir);
+    export_schema(&schema_for!(HandleMsg), &schema_dir);
+    export_schema(&schema_for!(QueryMsg), &schema_dir);
+    export_schema(&schema_for!(QueryAnswer), &schema_dir);
+}

--- a/contracts/micro_mint/Cargo.toml
+++ b/contracts/micro_mint/Cargo.toml
@@ -47,3 +47,7 @@ serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 snafu = { version = "0.6.3" }
 mockall = "0.10.2"
 mockall_double = "0.2.0"
+
+[build-dependencies]
+cosmwasm-schema = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
+shade-protocol = { version = "0.1.0", path = "../../packages/shade_protocol" }

--- a/contracts/micro_mint/build.rs
+++ b/contracts/micro_mint/build.rs
@@ -1,0 +1,30 @@
+use std::path::PathBuf;
+
+use cosmwasm_schema::{export_schema, schema_for};
+use shade_protocol::micro_mint::{HandleAnswer, HandleMsg, InitMsg, QueryAnswer, QueryMsg};
+
+fn main() {
+    // only generate schemas when building in release mode
+    if cfg!(debug_assertions) {
+        return;
+    }
+
+    let package_dir = env!("CARGO_MANIFEST_DIR");
+    let schema_dir = format!("{}/schema", package_dir);
+
+    if std::fs::metadata(&schema_dir).is_ok() {
+        // if the schemas already exist, only regenerate if the package has changed
+        println!("cargo:rerun-if-changed=../../packages/shade_protocol/src");
+        std::fs::remove_dir_all(&schema_dir).expect("remove stale schemas");
+    }
+
+    std::fs::create_dir(&schema_dir).expect("create schema directory");
+
+    let schema_dir = PathBuf::from(schema_dir);
+
+    export_schema(&schema_for!(InitMsg), &schema_dir);
+    export_schema(&schema_for!(HandleMsg), &schema_dir);
+    export_schema(&schema_for!(HandleAnswer), &schema_dir);
+    export_schema(&schema_for!(QueryMsg), &schema_dir);
+    export_schema(&schema_for!(QueryAnswer), &schema_dir);
+}

--- a/contracts/mint/Cargo.toml
+++ b/contracts/mint/Cargo.toml
@@ -42,3 +42,7 @@ shade-protocol = { version = "0.1.0", path = "../../packages/shade_protocol" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 snafu = { version = "0.6.3" }
+
+[build-dependencies]
+cosmwasm-schema = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
+shade-protocol = { version = "0.1.0", path = "../../packages/shade_protocol" }

--- a/contracts/mint/build.rs
+++ b/contracts/mint/build.rs
@@ -1,0 +1,30 @@
+use std::path::PathBuf;
+
+use cosmwasm_schema::{export_schema, schema_for};
+use shade_protocol::mint::{HandleAnswer, HandleMsg, InitMsg, QueryAnswer, QueryMsg};
+
+fn main() {
+    // only generate schemas when building in release mode
+    if cfg!(debug_assertions) {
+        return;
+    }
+
+    let package_dir = env!("CARGO_MANIFEST_DIR");
+    let schema_dir = format!("{}/schema", package_dir);
+
+    if std::fs::metadata(&schema_dir).is_ok() {
+        // if the schemas already exist, only regenerate if the package has changed
+        println!("cargo:rerun-if-changed=../../packages/shade_protocol/src");
+        std::fs::remove_dir_all(&schema_dir).expect("remove stale schemas");
+    }
+
+    std::fs::create_dir(&schema_dir).expect("create schema directory");
+
+    let schema_dir = PathBuf::from(schema_dir);
+
+    export_schema(&schema_for!(InitMsg), &schema_dir);
+    export_schema(&schema_for!(HandleMsg), &schema_dir);
+    export_schema(&schema_for!(HandleAnswer), &schema_dir);
+    export_schema(&schema_for!(QueryMsg), &schema_dir);
+    export_schema(&schema_for!(QueryAnswer), &schema_dir);
+}

--- a/contracts/oracle/Cargo.toml
+++ b/contracts/oracle/Cargo.toml
@@ -48,3 +48,7 @@ serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 snafu = { version = "0.6.3" }
 
 mockall = "0.10.2"
+
+[build-dependencies]
+cosmwasm-schema = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
+shade-protocol = { version = "0.1.0", path = "../../packages/shade_protocol" }

--- a/contracts/oracle/build.rs
+++ b/contracts/oracle/build.rs
@@ -1,0 +1,30 @@
+use std::path::PathBuf;
+
+use cosmwasm_schema::{export_schema, schema_for};
+use shade_protocol::oracle::{HandleAnswer, HandleMsg, InitMsg, QueryAnswer, QueryMsg};
+
+fn main() {
+    // only generate schemas when building in release mode
+    if cfg!(debug_assertions) {
+        return;
+    }
+
+    let package_dir = env!("CARGO_MANIFEST_DIR");
+    let schema_dir = format!("{}/schema", package_dir);
+
+    if std::fs::metadata(&schema_dir).is_ok() {
+        // if the schemas already exist, only regenerate if the package has changed
+        println!("cargo:rerun-if-changed=../../packages/shade_protocol/src");
+        std::fs::remove_dir_all(&schema_dir).expect("remove stale schemas");
+    }
+
+    std::fs::create_dir(&schema_dir).expect("create schema directory");
+
+    let schema_dir = PathBuf::from(schema_dir);
+
+    export_schema(&schema_for!(InitMsg), &schema_dir);
+    export_schema(&schema_for!(HandleMsg), &schema_dir);
+    export_schema(&schema_for!(HandleAnswer), &schema_dir);
+    export_schema(&schema_for!(QueryMsg), &schema_dir);
+    export_schema(&schema_for!(QueryAnswer), &schema_dir);
+}

--- a/contracts/staking/Cargo.toml
+++ b/contracts/staking/Cargo.toml
@@ -45,3 +45,7 @@ snafu = { version = "0.6.3" }
 mockall = "0.10.2"
 mockall_double = "0.2.0"
 binary-heap-plus = { version = "0.4.1", features = ["serde"] }
+
+[build-dependencies]
+cosmwasm-schema = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
+shade-protocol = { version = "0.1.0", path = "../../packages/shade_protocol" }

--- a/contracts/staking/build.rs
+++ b/contracts/staking/build.rs
@@ -1,0 +1,30 @@
+use std::path::PathBuf;
+
+use cosmwasm_schema::{export_schema, schema_for};
+use shade_protocol::staking::{HandleAnswer, HandleMsg, InitMsg, QueryAnswer, QueryMsg};
+
+fn main() {
+    // only generate schemas when building in release mode
+    if cfg!(debug_assertions) {
+        return;
+    }
+
+    let package_dir = env!("CARGO_MANIFEST_DIR");
+    let schema_dir = format!("{}/schema", package_dir);
+
+    if std::fs::metadata(&schema_dir).is_ok() {
+        // if the schemas already exist, only regenerate if the package has changed
+        println!("cargo:rerun-if-changed=../../packages/shade_protocol/src");
+        std::fs::remove_dir_all(&schema_dir).expect("remove stale schemas");
+    }
+
+    std::fs::create_dir(&schema_dir).expect("create schema directory");
+
+    let schema_dir = PathBuf::from(schema_dir);
+
+    export_schema(&schema_for!(InitMsg), &schema_dir);
+    export_schema(&schema_for!(HandleMsg), &schema_dir);
+    export_schema(&schema_for!(HandleAnswer), &schema_dir);
+    export_schema(&schema_for!(QueryMsg), &schema_dir);
+    export_schema(&schema_for!(QueryAnswer), &schema_dir);
+}

--- a/contracts/treasury/Cargo.toml
+++ b/contracts/treasury/Cargo.toml
@@ -42,3 +42,7 @@ shade-protocol = { version = "0.1.0", path = "../../packages/shade_protocol" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 snafu = { version = "0.6.3" }
+
+[build-dependencies]
+cosmwasm-schema = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
+shade-protocol = { version = "0.1.0", path = "../../packages/shade_protocol" }

--- a/contracts/treasury/build.rs
+++ b/contracts/treasury/build.rs
@@ -1,0 +1,30 @@
+use std::path::PathBuf;
+
+use cosmwasm_schema::{export_schema, schema_for};
+use shade_protocol::treasury::{HandleAnswer, HandleMsg, InitMsg, QueryAnswer, QueryMsg};
+
+fn main() {
+    // only generate schemas when building in release mode
+    if cfg!(debug_assertions) {
+        return;
+    }
+
+    let package_dir = env!("CARGO_MANIFEST_DIR");
+    let schema_dir = format!("{}/schema", package_dir);
+
+    if std::fs::metadata(&schema_dir).is_ok() {
+        // if the schemas already exist, only regenerate if the package has changed
+        println!("cargo:rerun-if-changed=../../packages/shade_protocol/src");
+        std::fs::remove_dir_all(&schema_dir).expect("remove stale schemas");
+    }
+
+    std::fs::create_dir(&schema_dir).expect("create schema directory");
+
+    let schema_dir = PathBuf::from(schema_dir);
+
+    export_schema(&schema_for!(InitMsg), &schema_dir);
+    export_schema(&schema_for!(HandleMsg), &schema_dir);
+    export_schema(&schema_for!(HandleAnswer), &schema_dir);
+    export_schema(&schema_for!(QueryMsg), &schema_dir);
+    export_schema(&schema_for!(QueryAnswer), &schema_dir);
+}


### PR DESCRIPTION
Adds a build script (`build.rs`) to each contract crate that will generate the CosmWasm schema when the crate is built in release mode. 

If the schemas are already present, it will only re-generate them if any files have changed in `packages/shade_protocol/src`.

I wasn't sure whether to ignore the generated schemas in git or not. Other projects seem to track them in git - possibly to make it easier for other projects to integrate without cloning and generating them.

If we want to track them, I can add them in another commit to this PR. 