### PR TITLE
Airdrop | completion flags

### DIFF
--- a/contracts/airdrop/src/contract.rs
+++ b/contracts/airdrop/src/contract.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{debug_print, to_binary, Api, Binary, Env, Extern, HandleResponse, InitResponse, Querier, StdResult, Storage, Uint128, HumanAddr};
+use cosmwasm_std::{debug_print, to_binary, Api, Binary, Env, Extern, HandleResponse, InitResponse, Querier, StdResult, Storage, Uint128, HumanAddr, StdError};
 use shade_protocol::{
     airdrop::{
         InitMsg, HandleMsg,
@@ -6,21 +6,42 @@ use shade_protocol::{
     }
 };
 use crate::{state::{config_w, reward_w, claim_status_w},
-            handle::{try_update_config, try_claim},
+            handle::{try_update_config, try_add_tasks, try_complete_task, try_claim},
             query };
 use secret_toolkit::snip20::token_info_query;
+use shade_protocol::airdrop::RequiredTask;
 
 pub fn init<S: Storage, A: Api, Q: Querier>(
     deps: &mut Extern<S, A, Q>,
     env: Env,
     msg: InitMsg,
 ) -> StdResult<InitResponse> {
+
+    // Setup task claim
+    let mut task_claim= vec![RequiredTask {
+        address: env.contract.address,
+        percent: msg.default_claim
+    }];
+    let mut claim = msg.task_claim;
+    task_claim.append(&mut claim);
+
+    // Validate claim percentage
+    let mut count = Uint128::zero();
+    for claim in task_claim.iter() {
+        count += claim.percent;
+    }
+
+    if count > Uint128(100) {
+        return Err(StdError::GenericErr { msg: "tasks above 100%".to_string(), backtrace: None })
+    }
+
     let config = Config{
         admin: match msg.admin {
             None => { env.message.sender.clone() }
             Some(admin) => { admin }
         },
-        airdrop_snip20: msg.airdrop_snip20.clone(),
+        airdrop_snip20: msg.airdrop_token.clone(),
+        task_claim,
         start_date: match msg.start_time {
             None => env.block.time,
             Some(date) => date
@@ -35,7 +56,8 @@ pub fn init<S: Storage, A: Api, Q: Querier>(
         let key = reward.address.to_string();
 
         reward_w(&mut deps.storage).save(key.as_bytes(), &reward)?;
-        claim_status_w(&mut deps.storage).save(key.as_bytes(), &false)?;
+        // Save the initial claim
+        claim_status_w(&mut deps.storage, 0).save(key.as_bytes(), &false)?;
     }
 
     Ok(InitResponse {
@@ -53,6 +75,10 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
         HandleMsg::UpdateConfig {
             admin, start_date, end_date
         } => try_update_config(deps, env, admin, start_date, end_date),
+        HandleMsg::AddTasks { tasks
+        } => try_add_tasks(deps, &env, tasks),
+        HandleMsg::CompleteTask { address
+        } => try_complete_task(deps, &env, address),
         HandleMsg::Claim { } => try_claim(deps, &env),
     }
 }

--- a/contracts/airdrop/src/contract.rs
+++ b/contracts/airdrop/src/contract.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{debug_print, to_binary, Api, Binary, Env, Extern, HandleResponse, InitResponse, Querier, StdResult, Storage, Uint128, HumanAddr, StdError};
+use cosmwasm_std::{to_binary, Api, Binary, Env, Extern, HandleResponse, InitResponse, Querier, StdResult, Storage, Uint128, StdError};
 use shade_protocol::{
     airdrop::{
         InitMsg, HandleMsg,
@@ -8,7 +8,6 @@ use shade_protocol::{
 use crate::{state::{config_w, reward_w, claim_status_w},
             handle::{try_update_config, try_add_tasks, try_complete_task, try_claim},
             query };
-use secret_toolkit::snip20::token_info_query;
 use shade_protocol::airdrop::RequiredTask;
 
 pub fn init<S: Storage, A: Api, Q: Querier>(

--- a/contracts/airdrop/src/handle.rs
+++ b/contracts/airdrop/src/handle.rs
@@ -1,7 +1,7 @@
 use cosmwasm_std::{debug_print, to_binary, Api, Binary, Env, Extern, HandleResponse, Querier, StdError, StdResult, Storage, CosmosMsg, HumanAddr, Uint128, from_binary, Empty};
 use shade_protocol::asset::Contract;
 use crate::state::{config_r, config_w, reward_r, claim_status_w, claim_status_r};
-use shade_protocol::airdrop::{HandleAnswer};
+use shade_protocol::airdrop::{HandleAnswer, RequiredTask};
 use shade_protocol::generic_response::ResponseStatus;
 use secret_toolkit::snip20::mint_msg;
 
@@ -42,6 +42,77 @@ pub fn try_update_config<S: Storage, A: Api, Q: Querier>(
     })
 }
 
+pub fn try_add_tasks<S: Storage, A: Api, Q: Querier>(
+    deps: &mut Extern<S, A, Q>,
+    env: &Env,
+    tasks: Vec<RequiredTask>
+) -> StdResult<HandleResponse> {
+
+    let config = config_r(&deps.storage).load()?;
+    // Check if admin
+    if env.message.sender != config.admin {
+        return Err(StdError::Unauthorized { backtrace: None });
+    }
+
+    config_w(&mut deps.storage).update(|mut config| {
+        let mut task_list = tasks;
+        config.task_claim.append(&mut task_list);
+
+        //Validate that they do not excede 100
+        let mut count = Uint128::zero();
+        for task in config.task_claim.iter() {
+            count += task.percent;
+        }
+
+        if count > Uint128(100) {
+            return Err(StdError::GenericErr { msg: "tasks above 100%".to_string(), backtrace: None })
+        }
+
+        Ok(config)
+    })?;
+
+    Ok(HandleResponse {
+        messages: vec![],
+        log: vec![],
+        data: Some( to_binary( &HandleAnswer::AddTask {
+            status: ResponseStatus::Success } )? )
+    })
+}
+
+pub fn try_complete_task<S: Storage, A: Api, Q: Querier>(
+    deps: &mut Extern<S, A, Q>,
+    env: &Env,
+    address: HumanAddr,
+) -> StdResult<HandleResponse> {
+
+    let config = config_r(&deps.storage).load()?;
+
+    for (i, item) in config.task_claim.iter().enumerate() {
+        if item.address == env.message.sender {
+            claim_status_w(&mut deps.storage, i).update(
+                address.to_string().as_bytes(), |status| {
+                    // If there was a state then ignore
+                    if status.is_none() {
+                        Ok(false)
+                    }
+                    else {
+                        Err(StdError::Unauthorized { backtrace: None })
+                    }
+                })?;
+
+            return Ok(HandleResponse {
+                messages: vec![],
+                log: vec![],
+                data: Some( to_binary( &HandleAnswer::Claim {
+                    status: ResponseStatus::Success } )? )
+            })
+        }
+    }
+
+    // if not found
+    Err(StdError::NotFound { kind: "task".to_string(), backtrace: None })
+}
+
 pub fn try_claim<S: Storage, A: Api, Q: Querier>(
     deps: &mut Extern<S, A, Q>,
     env: &Env,
@@ -58,31 +129,32 @@ pub fn try_claim<S: Storage, A: Api, Q: Querier>(
         }
     }
 
-    let key = env.message.sender.to_string();
+    let user = env.message.sender.clone();
+    let user_key = user.to_string();
 
-    // Check if user is eligible
-    match claim_status_r(&deps.storage).load(key.as_bytes()) {
-        Ok(claimed) => {
-            if claimed {
-                return Err(StdError::GenericErr { msg: "Already Claimed".to_string(), backtrace: None })
+    let eligible_amount = reward_r(&deps.storage).load(
+        user.to_string().as_bytes())?.amount;
+
+    let mut total = Uint128::zero();
+    for (i, task) in config.task_claim.iter().enumerate() {
+        // Check if completed
+        let state = claim_status_r(&deps.storage, i).may_load(user_key.as_bytes())?;
+        match state {
+            None => {}
+            Some(claimed) => {
+                if !claimed {
+                    claim_status_w(&mut deps.storage, i).save(user_key.as_bytes(), &true)?;
+                    total += task.percent.multiply_ratio(eligible_amount, Uint128(100));
+                }
             }
-        }
-        Err(_) => return Err(StdError::GenericErr { msg: "Not eligible".to_string(), backtrace: None })
+        };
     }
 
-    // Load the user's reward
-    let airdrop = reward_r(&deps.storage).load(key.as_bytes())?;
-
     // Redeem
-    let messages =  vec![mint_msg(env.message.sender.clone(), airdrop.amount,
+    let messages =  vec![mint_msg(user, total,
                                   None, 1,
                                   config.airdrop_snip20.code_hash,
                                   config.airdrop_snip20.address)?];
-
-    // Mark reward as redeemed
-    claim_status_w(&mut deps.storage).update(key.as_bytes(), |claimed| {
-        Ok(true)
-    })?;
 
     Ok(HandleResponse {
         messages,

--- a/contracts/airdrop/src/handle.rs
+++ b/contracts/airdrop/src/handle.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{to_binary, Api, Env, Extern, HandleResponse, Querier, StdError, StdResult, Storage, HumanAddr};
+use cosmwasm_std::{to_binary, Api, Env, Extern, HandleResponse, Querier, StdError, StdResult, Storage, HumanAddr, Uint128};
 use crate::state::{config_r, config_w, reward_r, claim_status_w, claim_status_r};
 use shade_protocol::airdrop::{HandleAnswer, RequiredTask};
 use shade_protocol::generic_response::ResponseStatus;

--- a/contracts/airdrop/src/query.rs
+++ b/contracts/airdrop/src/query.rs
@@ -30,18 +30,15 @@ pub fn airdrop_amount<S: Storage, A: Api, Q: Querier>
     for (i, task) in config.task_claim.iter().enumerate() {
         let state = claim_status_r(&deps.storage, i).may_load(key.as_bytes())?;
 
-        match state {
-            None => {}
-            Some(task_claimed) => {
-                finished_tasks.push(task.clone());
-                let calc = task.percent.multiply_ratio(eligible_amount.clone(),
-                                                       Uint128(100));
-                match task_claimed {
-                    true => claimed += calc,
-                    false => unclaimed += calc
-                };
-            }
-        };
+        if let Some(task_claimed) = state {
+            finished_tasks.push(task.clone());
+            let calc = task.percent.multiply_ratio(eligible_amount.clone(),
+                                                   Uint128(100));
+            match task_claimed {
+                true => claimed += calc,
+                false => unclaimed += calc
+            };
+        }
     }
 
     Ok(QueryAnswer::Eligibility {

--- a/contracts/airdrop/src/query.rs
+++ b/contracts/airdrop/src/query.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Api, Extern, Querier, StdResult, Storage, HumanAddr};
+use cosmwasm_std::{Api, Extern, Querier, StdResult, Storage, HumanAddr, Uint128};
 use shade_protocol::airdrop::{QueryAnswer};
 use crate::{state::{config_r, reward_r}};
 use crate::state::claim_status_r;

--- a/contracts/airdrop/src/state.rs
+++ b/contracts/airdrop/src/state.rs
@@ -4,7 +4,6 @@ use shade_protocol::airdrop::{Config, Reward};
 
 pub static CONFIG_KEY: &[u8] = b"config";
 pub static REWARDS_KEY: &[u8] = b"rewards";
-pub static CLAIM_STATUS_KEY: &[u8] = b"claim_status";
 
 pub fn config_w<S: Storage>(storage: &mut S) -> Singleton<S, Config> {
     singleton(storage, CONFIG_KEY)
@@ -22,10 +21,11 @@ pub fn reward_w<S: Storage>(storage: &mut S) -> Bucket<S, Reward> {
     bucket(REWARDS_KEY, storage)
 }
 
-pub fn claim_status_r<S: Storage>(storage: & S) -> ReadonlyBucket<S, bool> {
-    bucket_read(CLAIM_STATUS_KEY, storage)
+// If not found then its unrewarded; if true then claimed
+pub fn claim_status_r<S: Storage>(storage: & S, index: usize) -> ReadonlyBucket<S, bool> {
+    bucket_read(&[index as u8], storage)
 }
 
-pub fn claim_status_w<S: Storage>(storage: &mut S) -> Bucket<S, bool> {
-    bucket(CLAIM_STATUS_KEY, storage)
+pub fn claim_status_w<S: Storage>(storage: &mut S, index: usize) -> Bucket<S, bool> {
+    bucket(&[index as u8], storage)
 }

--- a/packages/network_integration/src/contract_helpers/initializer.rs
+++ b/packages/network_integration/src/contract_helpers/initializer.rs
@@ -3,12 +3,12 @@ use cosmwasm_std::{HumanAddr, Uint128};
 use shade_protocol::{snip20::{InitialBalance}, snip20,
                      initializer, initializer::Snip20ContractInfo};
 use crate::{utils::{print_header, generate_label, print_contract, print_warning,
-                    STORE_GAS, GAS, VIEW_KEY, ACCOUNT_KEY},
+                    STORE_GAS, GAS, VIEW_KEY, ACCOUNT_KEY, INITIALIZER_FILE},
             contract_helpers::governance::add_contract,
             contract_helpers::minter::get_balance};
 use secretcli::{cli_types::NetContract,
-                secretcli::{query_contract, test_contract_handle, test_inst_init}};
-use secretcli::secretcli::list_contracts_by_code;
+                secretcli::{query_contract, test_contract_handle,
+                            test_inst_init, list_contracts_by_code}};
 
 pub fn initialize_initializer(
     governance: &NetContract, sSCRT: &NetContract, account: String) -> Result<()> {
@@ -45,7 +45,7 @@ pub fn initialize_initializer(
         }
     };
 
-    let initializer = test_inst_init(&init_msg, "../../compiled/initializer.wasm.gz", &*generate_label(8),
+    let initializer = test_inst_init(&init_msg, INITIALIZER_FILE, &*generate_label(8),
                 ACCOUNT_KEY, Some(STORE_GAS), Some(GAS),
                 Some("test"))?;
     print_contract(&initializer);

--- a/packages/network_integration/src/contract_helpers/initializer.rs
+++ b/packages/network_integration/src/contract_helpers/initializer.rs
@@ -7,8 +7,7 @@ use crate::{utils::{print_header, generate_label, print_contract, print_warning,
             contract_helpers::governance::add_contract,
             contract_helpers::minter::get_balance};
 use secretcli::{cli_types::NetContract,
-                secretcli::{query_contract, test_contract_handle,
-                            test_inst_init, list_contracts_by_code}};
+                secretcli::{test_contract_handle, test_inst_init, list_contracts_by_code}};
 
 pub fn initialize_initializer(
     governance: &NetContract, sscrt: &NetContract, account: String) -> Result<()> {

--- a/packages/network_integration/src/contract_helpers/minter.rs
+++ b/packages/network_integration/src/contract_helpers/minter.rs
@@ -2,11 +2,11 @@ use serde_json::Result;
 use cosmwasm_std::{HumanAddr, Uint128, to_binary};
 use shade_protocol::{snip20, micro_mint, mint, asset::Contract};
 use crate::{utils::{print_header, print_contract, print_epoch_info, print_vec,
-                    STORE_GAS, GAS, VIEW_KEY, ACCOUNT_KEY, MICRO_MINT_FILE},
-            contract_helpers::governance::{init_contract, get_contract, add_contract,
-                                           create_and_trigger_proposal, trigger_latest_proposal}};
+                    GAS, VIEW_KEY, MICRO_MINT_FILE},
+            contract_helpers::governance::{init_contract, get_contract,
+                                           create_and_trigger_proposal}};
 use secretcli::{cli_types::NetContract,
-                secretcli::{query_contract, test_contract_handle, test_inst_init}};
+                secretcli::{query_contract, test_contract_handle}};
 
 pub fn initialize_minter(governance: &NetContract, contract_name: String,
                          native_asset: &Contract) -> Result<NetContract> {

--- a/packages/network_integration/src/contract_helpers/minter.rs
+++ b/packages/network_integration/src/contract_helpers/minter.rs
@@ -2,7 +2,7 @@ use serde_json::Result;
 use cosmwasm_std::{HumanAddr, Uint128, to_binary};
 use shade_protocol::{snip20, micro_mint, mint, asset::Contract};
 use crate::{utils::{print_header, print_contract, print_epoch_info, print_vec,
-                    STORE_GAS, GAS, VIEW_KEY, ACCOUNT_KEY},
+                    STORE_GAS, GAS, VIEW_KEY, ACCOUNT_KEY, MICRO_MINT_FILE},
             contract_helpers::governance::{init_contract, get_contract, add_contract,
                                            create_and_trigger_proposal, trigger_latest_proposal}};
 use secretcli::{cli_types::NetContract,
@@ -11,7 +11,7 @@ use secretcli::{cli_types::NetContract,
 pub fn initialize_minter(governance: &NetContract, contract_name: String,
                          native_asset: &Contract) -> Result<NetContract> {
     let minter = init_contract(governance, contract_name,
-                                   "../../compiled/micro_mint.wasm.gz",
+                                   MICRO_MINT_FILE,
                                    micro_mint::InitMsg {
             admin: Some(HumanAddr::from(governance.address.clone())),
             native_asset: native_asset.clone(),

--- a/packages/network_integration/src/contract_helpers/stake.rs
+++ b/packages/network_integration/src/contract_helpers/stake.rs
@@ -1,13 +1,9 @@
 use serde_json::Result;
 use cosmwasm_std::{HumanAddr, Uint128};
 use shade_protocol::{staking, snip20, asset::Contract};
-use crate::{utils::{print_header, print_contract, print_epoch_info, print_vec,
-                    STORE_GAS, GAS, VIEW_KEY, ACCOUNT_KEY, STAKING_FILE},
-            contract_helpers::governance::{init_contract, get_contract, add_contract,
-                                           create_and_trigger_proposal, trigger_latest_proposal}};
 use crate::{utils::{print_header, print_contract,
-                    GAS, ACCOUNT_KEY},
-            contract_helpers::governance::init_contract};
+                    GAS, ACCOUNT_KEY, STAKING_FILE},
+            contract_helpers::governance::{init_contract}};
 use secretcli::{cli_types::NetContract,
                 secretcli::{query_contract, test_contract_handle}};
 use crate::contract_helpers::minter::get_balance;

--- a/packages/network_integration/src/contract_helpers/stake.rs
+++ b/packages/network_integration/src/contract_helpers/stake.rs
@@ -2,7 +2,7 @@ use serde_json::Result;
 use cosmwasm_std::{HumanAddr, Uint128, to_binary};
 use shade_protocol::{staking, snip20, asset::Contract};
 use crate::{utils::{print_header, print_contract, print_epoch_info, print_vec,
-                    STORE_GAS, GAS, VIEW_KEY, ACCOUNT_KEY},
+                    STORE_GAS, GAS, VIEW_KEY, ACCOUNT_KEY, STAKING_FILE},
             contract_helpers::governance::{init_contract, get_contract, add_contract,
                                            create_and_trigger_proposal, trigger_latest_proposal}};
 use secretcli::{cli_types::NetContract,
@@ -12,7 +12,7 @@ use std::{thread, time};
 
 pub fn setup_staker(governance: &NetContract, shade: &Contract, staking_account: String) -> Result<NetContract> {
     let staker = init_contract(&governance, "staking".to_string(),
-                               "../../compiled/staking.wasm.gz",
+                               STAKING_FILE,
                                staking::InitMsg{
                                    admin: Some(Contract{
                                        address: HumanAddr::from(governance.address.clone()),

--- a/packages/network_integration/src/utils.rs
+++ b/packages/network_integration/src/utils.rs
@@ -8,6 +8,17 @@ use serde::Serialize;
 use secretcli::{cli_types::NetContract,
                 secretcli::{query_contract, test_contract_handle, test_inst_init}};
 
+// Smart contracts
+pub const SNIP20_FILE: &str = "../../compiled/snip20.wasm.gz";
+pub const AIRDROP_FILE: &str = "../../compiled/airdrop.wasm.gz";
+pub const GOVERNANCE_FILE: &str = "../../compiled/governance.wasm.gz";
+pub const MOCK_BAND_FILE: &str = "../../compiled/mock_band.wasm.gz";
+pub const ORACLE_FILE: &str = "../../compiled/oracle.wasm.gz";
+pub const INITIALIZER_FILE: &str = "../../compiled/initializer.wasm.gz";
+pub const MICRO_MINT_FILE: &str = "../../compiled/micro_mint.wasm.gz";
+pub const STAKING_FILE: &str = "../../compiled/staking.wasm.gz";
+
+
 pub const STORE_GAS: &str = "10000000";
 pub const GAS: &str = "800000";
 pub const VIEW_KEY: &str = "password";

--- a/packages/network_integration/tests/testnet_integration.rs
+++ b/packages/network_integration/tests/testnet_integration.rs
@@ -61,7 +61,7 @@ fn run_airdrop() -> Result<()> {
 
     let airdrop_init_msg = airdrop::InitMsg {
         admin: None,
-        airdrop_snip20: Contract {
+        airdrop_token: Contract {
             address: HumanAddr::from(snip.address.clone()),
             code_hash: snip.code_hash.clone()
         },

--- a/packages/network_integration/tests/testnet_integration.rs
+++ b/packages/network_integration/tests/testnet_integration.rs
@@ -5,10 +5,12 @@ use secretcli::{cli_types::NetContract,
                 secretcli::{account_address, query_contract, test_contract_handle,
                             test_inst_init, list_contracts_by_code}};
 use shade_protocol::{snip20::{InitConfig, InitialBalance}, snip20, governance, staking,
-                     micro_mint, band, oracle, asset::Contract, airdrop, airdrop::Reward,
+                     micro_mint, band, oracle, asset::Contract, airdrop,
+                     airdrop::{Reward, RequiredTask},
                      governance::{UserVote, Vote, ProposalStatus}, generic_response::ResponseStatus};
 use network_integration::{utils::{print_header, print_warning, generate_label, print_contract,
-                             STORE_GAS, GAS, VIEW_KEY, ACCOUNT_KEY, print_vec},
+                             STORE_GAS, GAS, VIEW_KEY, ACCOUNT_KEY, print_vec,
+                                  SNIP20_FILE, AIRDROP_FILE, GOVERNANCE_FILE, MOCK_BAND_FILE, ORACLE_FILE},
                      contract_helpers::{initializer::initialize_initializer,
                                         governance::{init_contract, get_contract, add_contract,
                                                      create_proposal, get_latest_proposal,
@@ -40,9 +42,10 @@ fn run_airdrop() -> Result<()> {
         })
     };
 
-    let snip = test_inst_init(&snip_init_msg, "../../compiled/snip20.wasm.gz", &*generate_label(8),
-                               ACCOUNT_KEY, Some(STORE_GAS), Some(GAS),
-                               Some("test"))?;
+    let snip = test_inst_init(&snip_init_msg, SNIP20_FILE,
+                              &*generate_label(8),
+                              ACCOUNT_KEY, Some(STORE_GAS), Some(GAS),
+                              Some("test"))?;
     print_contract(&snip);
 
     {
@@ -55,7 +58,8 @@ fn run_airdrop() -> Result<()> {
     /// Assert that we start with nothing
     assert_eq!(Uint128(0), get_balance(&snip, account.clone()));
 
-    let expected_airdrop = Uint128(1000000);
+    let half_airdrop = Uint128(500000);
+    let full_airdrop = Uint128(1000000);
 
     print_header("Initializing airdrop");
 
@@ -69,11 +73,15 @@ fn run_airdrop() -> Result<()> {
         end_time: None,
         rewards: vec![Reward {
             address: HumanAddr::from(account.clone()),
-            amount: expected_airdrop
-        }]
+            amount: full_airdrop
+        }],
+        default_claim: Uint128(50),
+        task_claim: vec![RequiredTask {
+            address: HumanAddr::from(account.clone()),
+            percent: Uint128(50) }]
     };
 
-    let airdrop = test_inst_init(&airdrop_init_msg, "../../compiled/airdrop.wasm.gz", &*generate_label(8),
+    let airdrop = test_inst_init(&airdrop_init_msg, AIRDROP_FILE, &*generate_label(8),
                               ACCOUNT_KEY, Some(STORE_GAS), Some(GAS),
                               Some("test"))?;
     print_contract(&airdrop);
@@ -86,9 +94,12 @@ fn run_airdrop() -> Result<()> {
 
         let query: airdrop::QueryAnswer = query_contract(&airdrop, msg)?;
 
-        if let airdrop::QueryAnswer::Eligibility { amount, claimed } = query {
-            assert_eq!(amount, expected_airdrop);
-            assert_eq!(claimed, false);
+        if let airdrop::QueryAnswer::Eligibility { total, claimed,
+            unclaimed, finished_tasks } = query {
+            assert_eq!(total, full_airdrop);
+            assert_eq!(claimed, Uint128::zero());
+            assert_eq!(unclaimed, half_airdrop);
+            assert_eq!(finished_tasks.len(), 1);
         }
     }
 
@@ -98,16 +109,16 @@ fn run_airdrop() -> Result<()> {
                          &snip, ACCOUNT_KEY, Some(GAS),
                          Some("test"), None)?;
 
-    print_header("Claiming airdrop");
+    print_warning("Claiming half of the airdrop");
     /// Claim airdrop
     test_contract_handle(&airdrop::HandleMsg::Claim {},
                          &airdrop, ACCOUNT_KEY, Some(GAS),
                          Some("test"), None)?;
 
     /// Assert that we claimed
-    assert_eq!(expected_airdrop, get_balance(&snip, account.clone()));
+    assert_eq!(half_airdrop, get_balance(&snip, account.clone()));
 
-    /// Query that airdrop is claimed
+    /// Query that half of the airdrop is claimed
     {
         let msg = airdrop::QueryMsg::GetEligibility {
             address: HumanAddr::from(account.clone())
@@ -115,9 +126,45 @@ fn run_airdrop() -> Result<()> {
 
         let query: airdrop::QueryAnswer = query_contract(&airdrop, msg)?;
 
-        if let airdrop::QueryAnswer::Eligibility { amount, claimed } = query {
-            assert_eq!(amount, expected_airdrop);
-            assert_eq!(claimed, true);
+        if let airdrop::QueryAnswer::Eligibility { total, claimed,
+            unclaimed, finished_tasks } = query {
+            assert_eq!(total, full_airdrop);
+            assert_eq!(claimed, half_airdrop);
+            assert_eq!(unclaimed, Uint128::zero());
+            assert_eq!(finished_tasks.len(), 1);
+        }
+    }
+
+    print_warning("Enabling the other half of the airdrop");
+
+    test_contract_handle(&airdrop::HandleMsg::CompleteTask {
+        address: HumanAddr::from(account.clone()) },
+                         &airdrop, ACCOUNT_KEY, Some(GAS),
+                         Some("test"), None)?;
+
+    print_warning("Claiming remaining half airdrop");
+
+    test_contract_handle(&airdrop::HandleMsg::Claim {},
+                         &airdrop, ACCOUNT_KEY, Some(GAS),
+                         Some("test"), None)?;
+
+    /// Assert that we claimed
+    assert_eq!(full_airdrop, get_balance(&snip, account.clone()));
+
+    /// Query that all of the airdrop is claimed
+    {
+        let msg = airdrop::QueryMsg::GetEligibility {
+            address: HumanAddr::from(account.clone())
+        };
+
+        let query: airdrop::QueryAnswer = query_contract(&airdrop, msg)?;
+
+        if let airdrop::QueryAnswer::Eligibility { total, claimed,
+            unclaimed, finished_tasks } = query {
+            assert_eq!(total, full_airdrop);
+            assert_eq!(claimed, full_airdrop);
+            assert_eq!(unclaimed, Uint128::zero());
+            assert_eq!(finished_tasks.len(), 2);
         }
     }
 
@@ -149,7 +196,7 @@ fn run_testnet() -> Result<()> {
         })
     };
 
-    let s_sCRT = test_inst_init(&sscrt_init_msg, "../../compiled/snip20.wasm.gz", &*generate_label(8),
+    let s_sCRT = test_inst_init(&sscrt_init_msg, SNIP20_FILE, &*generate_label(8),
                                 ACCOUNT_KEY, Some(STORE_GAS), Some(GAS),
                                 Some("test"))?;
     print_contract(&s_sCRT);
@@ -184,7 +231,7 @@ fn run_testnet() -> Result<()> {
         quorum: Uint128(5000000)
     };
 
-    let governance = test_inst_init(&governance_init_msg, "../../compiled/governance.wasm.gz", &*generate_label(8),
+    let governance = test_inst_init(&governance_init_msg, GOVERNANCE_FILE, &*generate_label(8),
                                     ACCOUNT_KEY, Some(STORE_GAS), Some(GAS),
                                     Some("test"))?;
 
@@ -212,12 +259,12 @@ fn run_testnet() -> Result<()> {
 
     // Initialize Band Mock
     let band = init_contract(&governance, "band_mock".to_string(),
-                             "../../compiled/mock_band.wasm.gz",
+                             MOCK_BAND_FILE,
                              band::InitMsg {})?;
 
     // Initialize Oracle
     let oracle = init_contract(&governance, "oracle".to_string(),
-                               "../../compiled/oracle.wasm.gz",
+                               ORACLE_FILE,
                                oracle::InitMsg {
                                    admin: None,
                                    band: Contract {

--- a/packages/shade_protocol/src/airdrop.rs
+++ b/packages/shade_protocol/src/airdrop.rs
@@ -6,10 +6,25 @@ use crate::asset::Contract;
 use crate::generic_response::ResponseStatus;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct RequiredTask {
+    pub address: HumanAddr,
+    pub percent: Uint128,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct Reward {
+    pub address: HumanAddr,
+    pub amount: Uint128,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Config {
     pub admin: HumanAddr,
     // The snip20 to be minted
     pub airdrop_snip20: Contract,
+    // Required tasks
+    pub task_claim: Vec<RequiredTask>,
     // Checks if airdrop has started / ended
     pub start_date: u64,
     pub end_date: Option<u64>,
@@ -18,13 +33,17 @@ pub struct Config {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InitMsg {
     pub admin: Option<HumanAddr>,
-    pub airdrop_snip20: Contract,
+    pub airdrop_token: Contract,
     // The airdrop time limit
     pub start_time: Option<u64>,
     // Can be set to never end
     pub end_time: Option<u64>,
     // Secret network delegators snapshot
     pub rewards: Vec<Reward>,
+    // Default gifted amount
+    pub default_claim: Uint128,
+    // The task related claims
+    pub task_claim: Vec<RequiredTask>
 }
 
 impl InitCallback for InitMsg {
@@ -39,6 +58,12 @@ pub enum HandleMsg {
         start_date: Option<u64>,
         end_date: Option<u64>,
     },
+    AddTasks {
+        tasks: Vec<RequiredTask>
+    },
+    CompleteTask {
+        address: HumanAddr
+    },
     Claim {}
 }
 
@@ -51,6 +76,8 @@ impl HandleCallback for HandleMsg {
 pub enum HandleAnswer {
     Init { status: ResponseStatus },
     UpdateConfig { status: ResponseStatus },
+    AddTask { status: ResponseStatus },
+    CompleteTask { status: ResponseStatus },
     Claim { status: ResponseStatus }
 }
 
@@ -71,12 +98,5 @@ impl Query for QueryMsg {
 pub enum QueryAnswer {
     Config { config: Config },
     Dates { start: u64, end: Option<u64> },
-    Eligibility { amount: Uint128, claimed: bool }
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-pub struct Reward {
-    pub address: HumanAddr,
-    pub amount: Uint128,
+    Eligibility { total: Uint128, claimed: Uint128, unclaimed: Uint128, finished_tasks: Vec<RequiredTask> }
 }

--- a/packages/shade_protocol/src/airdrop.rs
+++ b/packages/shade_protocol/src/airdrop.rs
@@ -98,5 +98,13 @@ impl Query for QueryMsg {
 pub enum QueryAnswer {
     Config { config: Config },
     Dates { start: u64, end: Option<u64> },
-    Eligibility { total: Uint128, claimed: Uint128, unclaimed: Uint128, finished_tasks: Vec<RequiredTask> }
+    Eligibility {
+        // Total eligible
+        total: Uint128,
+        // Total claimed
+        claimed: Uint128,
+        // Total unclaimed but available
+        unclaimed: Uint128,
+        finished_tasks: Vec<RequiredTask>
+    }
 }


### PR DESCRIPTION
Added completion flags for airdrop

The flags can be added before and after deployment, each flag points to an address which will be the contracts that notify the airdrop contract when a user is eligible for that portion of the airdrop