### PR TITLE
Governance | pre voting

### DIFF
--- a/contracts/governance/Cargo.toml
+++ b/contracts/governance/Cargo.toml
@@ -37,7 +37,8 @@ debug-print = ["cosmwasm-std/debug-print"]
 cosmwasm-schema = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
 cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
 cosmwasm-storage = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-secret-toolkit = { git = "https://github.com/enigmampc/secret-toolkit", branch = "debug-print"}
+# TODO: Update when secret-toolkit accepts the branch
+secret-toolkit = { git = "https://github.com/FloppyDisck/secret-toolkit", branch = "snip20-batch-transactions"}
 shade-protocol = { version = "0.1.0", path = "../../packages/shade_protocol" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/governance/src/contract.rs
+++ b/contracts/governance/src/contract.rs
@@ -59,12 +59,15 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
     msg: HandleMsg,
 ) -> StdResult<HandleResponse> {
     match msg {
-        /// Proposals
+        // Proposals
         HandleMsg::CreateProposal { target_contract, proposal, description
         } => handle::try_create_proposal(deps, &env, target_contract,
                                          Binary::from(proposal.as_bytes()), description),
 
-        /// Self interactions
+        HandleMsg::Receive {sender, amount, msg
+        } => handle::try_fund_proposal(deps, &env, sender, amount, msg),
+
+        // Self interactions
         // Config
         HandleMsg::UpdateConfig { admin, staker, proposal_deadline,
             funding_amount, funding_deadline, minimum_votes } =>
@@ -93,14 +96,14 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
         HandleMsg::UpdateAdminCommand { name, proposal
         } => handle::try_update_admin_command(deps, &env, name, proposal),
 
-        /// User interaction
+        // User interaction
         HandleMsg::MakeVote { voter, proposal_id, votes
         } => handle::try_vote(deps, &env, voter, proposal_id, votes),
 
         HandleMsg::TriggerProposal { proposal_id
         } => handle::try_trigger_proposal(deps, &env, proposal_id),
 
-        /// Admin interactions
+        // Admin interactions
         HandleMsg::TriggerAdminCommand { target, command,
             variables, description
         } => handle::try_trigger_admin_command(deps, &env, target, command, variables, description),

--- a/contracts/governance/src/handle.rs
+++ b/contracts/governance/src/handle.rs
@@ -286,7 +286,7 @@ pub fn try_trigger_proposal<S: Storage, A: Api, Q: Querier>(
         run_status = Failure;
     }
     else {
-        run_status = match try_execute_msg(target.unwrap(), proposal.msg.clone()) {
+        run_status = match try_execute_msg(target.unwrap(), proposal.msg) {
             Ok(msg) => {
                 messages.push(msg);
                 Success

--- a/contracts/governance/src/handle.rs
+++ b/contracts/governance/src/handle.rs
@@ -1,14 +1,29 @@
-use cosmwasm_std::{to_binary, Api, Binary, Env, Extern, HandleResponse, Querier, StdError, StdResult, Storage, CosmosMsg, HumanAddr, Uint128, WasmMsg, Empty};
-use crate::state::{supported_contract_r, config_r, total_proposals_w, proposal_w, config_w, supported_contract_w, proposal_r, admin_commands_r, admin_commands_w, admin_commands_list_w, supported_contracts_list_w, total_proposals_r, total_proposal_votes_w, proposal_votes_w, total_proposal_votes_r, proposal_votes_r};
-use shade_protocol::{
-    governance::{Proposal, ProposalStatus, HandleAnswer, GOVERNANCE_SELF, HandleMsg},
-    generic_response::ResponseStatus,
-    asset::Contract,
+use cosmwasm_std::{
+    to_binary, Api, Binary, Env, Extern, HandleResponse, Querier, StdError,
+    StdResult, Storage, CosmosMsg, HumanAddr, Uint128, WasmMsg
 };
-use shade_protocol::governance::ProposalStatus::{Accepted, Expired, Rejected};
-use shade_protocol::generic_response::ResponseStatus::{Success, Failure};
-use shade_protocol::governance::{AdminCommand, ADMIN_COMMAND_VARIABLE, Vote, UserVote, VoteTally};
-use secret_toolkit::utils::HandleCallback;
+use crate::{
+    proposal_state::{
+        proposal_w, proposal_r, total_proposals_w, total_proposals_r,
+        total_proposal_votes_w, total_proposal_votes_r, proposal_votes_w, proposal_votes_r,
+        proposal_funding_deadline_w, proposal_funding_deadline_r,
+        proposal_voting_deadline_w, proposal_voting_deadline_r, proposal_status_w, proposal_status_r,
+        proposal_run_status_r, proposal_run_status_w, proposal_funding_r, proposal_funding_w
+    },
+    state::{
+        supported_contract_r, config_r,  config_w, supported_contract_w,
+        admin_commands_r, admin_commands_w, admin_commands_list_w, supported_contracts_list_w
+    }
+};
+use shade_protocol::{
+    generic_response::ResponseStatus::{Success, Failure}, asset::Contract,
+    governance::{
+        Proposal, ProposalStatus, HandleAnswer, GOVERNANCE_SELF,
+        AdminCommand, ADMIN_COMMAND_VARIABLE, Vote, HandleMsg,
+        UserVote, VoteTally, ProposalStatus::{Passed, Expired, Rejected}
+    }
+};
+use shade_protocol::generic_response::ResponseStatus;
 
 pub fn create_proposal<S: Storage, A: Api, Q: Querier>(
     deps: &mut Extern<S, A, Q>,
@@ -37,21 +52,30 @@ pub fn create_proposal<S: Storage, A: Api, Q: Querier>(
         target: target_contract,
         msg: proposal,
         description,
-        is_admin_command: false,
-        due_date: env.block.time + config_r(&deps.storage).load()?.proposal_deadline,
-        vote_status: ProposalStatus::InProgress,
-        run_status: None
     };
 
+    let config = config_r(&deps.storage).load()?;
+
     // Store the proposal
-    proposal_w(&mut deps.storage).save(proposal_id.to_string().as_bytes(), &proposal)?;
+    proposal_w(&mut deps.storage).save(
+        proposal_id.to_string().as_bytes(), &proposal)?;
+    // TODO: REMOVE THIS - THIS IS JUST FOR INITIAL TESTING
+    proposal_funding_deadline_w(&mut deps.storage).save(
+        proposal_id.to_string().as_bytes(), &(env.block.time + config.funding_deadline))?;
+    proposal_funding_w(&mut deps.storage).save(
+        proposal_id.to_string().as_bytes(), &Uint128::zero())?;
+    proposal_voting_deadline_w(&mut deps.storage).save(
+        proposal_id.to_string().as_bytes(), &(env.block.time + config.voting_deadline))?;
+    // TODO: CHANGE TO FUNDING
+    proposal_status_w(&mut deps.storage).save(
+        proposal_id.to_string().as_bytes(), &ProposalStatus::InProgress)?;
 
     // Create proposal votes
     total_proposal_votes_w(&mut deps.storage).save(
         proposal_id.to_string().as_bytes(), &VoteTally{
-        yes: Uint128(0),
-        no: Uint128(0),
-        abstain: Uint128(0)
+        yes: Uint128::zero(),
+        no: Uint128::zero(),
+        abstain: Uint128::zero()
     })?;
 
     Ok(proposal_id)
@@ -65,31 +89,32 @@ pub fn try_trigger_proposal<S: Storage, A: Api, Q: Querier>(
 
     // Get proposal
     let mut proposal = proposal_r(&deps.storage).load(proposal_id.to_string().as_bytes())?;
+    let mut run_status: ResponseStatus;
+    let mut vote_status = proposal_status_r(&deps.storage).load(proposal_id.to_string().as_bytes())?;
+    let voting_deadline = proposal_voting_deadline_r(&deps.storage).may_load(proposal_id.to_string().as_bytes())?.ok_or_else(|| StdError::generic_err("No deadline set"))?;
 
     // Check if proposal has run
-    if proposal.run_status.is_some() {
-        return Err(StdError::GenericErr {
-            msg: "Proposal has already been executed".to_string(),
-            backtrace: None })
+    if proposal_run_status_r(&deps.storage).may_load(proposal_id.to_string().as_bytes())?.is_some() {
+        return Err(StdError::generic_err("Proposal has already been executed"))
     }
 
     // Change proposal behavior according to stake availability
     let config = config_r(&deps.storage).load()?;
-    proposal.vote_status = match config.staker {
+    vote_status = match config.staker {
         Some(staker) => {
 
             let total_votes = total_proposal_votes_r(&deps.storage).load(
                 proposal_id.to_string().as_bytes())?;
 
             // Check if proposal can be run
-            if proposal.due_date > env.block.time {
-                Err(StdError::Unauthorized { backtrace: None })
+            if voting_deadline > env.block.time {
+                Err(StdError::unauthorized())
             }
             else if total_votes.yes + total_votes.no + total_votes.abstain < config.minimum_votes {
                 Ok(Expired)
             }
             else if total_votes.yes > total_votes.no {
-                Ok(Accepted)
+                Ok(Passed)
             }
             else {
                 Ok(Rejected)
@@ -98,9 +123,9 @@ pub fn try_trigger_proposal<S: Storage, A: Api, Q: Querier>(
         None => {
             // Check if user is an admin in order to trigger the proposal
             if config.admin == env.message.sender {
-                Ok(Accepted)
+                Ok(Passed)
             } else {
-                Err(StdError::Unauthorized { backtrace: None })
+                Err(StdError::unauthorized())
             }
         }
     }?;
@@ -119,27 +144,30 @@ pub fn try_trigger_proposal<S: Storage, A: Api, Q: Querier>(
     }
 
     // Check if proposal passed or has a valid target contract
-    if proposal.vote_status != Accepted || target.is_none() {
-        proposal.run_status = Some(Failure);
+    if vote_status != Passed || target.is_none() {
+        run_status = Failure;
     }
     else {
-        match try_execute_msg(target.unwrap(), proposal.msg.clone()) {
+        run_status = match try_execute_msg(target.unwrap(), proposal.msg.clone()) {
             Ok(msg) => {
-                proposal.run_status = Some(Success);
                 messages.push(msg);
+                Success
             }
-            Err(_) => proposal.run_status = Some(Failure),
+            Err(_) => Failure,
         };
     }
 
     // Overwrite
     proposal_w(&mut deps.storage).save(proposal_id.to_string().as_bytes(), &proposal)?;
+    proposal_run_status_w(&mut deps.storage).save(proposal_id.to_string().as_bytes(), &run_status)?;
+    proposal_status_w(&mut deps.storage).save(proposal_id.to_string().as_bytes(), &vote_status)?;
+
 
     Ok(HandleResponse {
         messages,
         log: vec![],
         data: Some( to_binary( &HandleAnswer::TriggerProposal {
-            status: proposal.run_status.unwrap(),
+            status: run_status,
         })?),
     })
 }
@@ -177,10 +205,13 @@ pub fn try_vote<S: Storage, A: Api, Q: Querier>(
     }
 
     // Check that proposal is still votable
-    let proposal = proposal_r(&deps.storage).load(proposal_id.to_string().as_bytes())?;
+    let vote_status = proposal_status_r(&deps.storage).load(
+        proposal_id.to_string().as_bytes())?;
+    let voting_deadline = proposal_voting_deadline_r(&deps.storage).may_load(
+        proposal_id.to_string().as_bytes())?.ok_or_else(|| StdError::generic_err("No deadline set"))?;
 
-    if proposal.vote_status != ProposalStatus::InProgress || proposal.due_date <= env.block.time {
-        return Err(StdError::Unauthorized { backtrace: None })
+    if vote_status != ProposalStatus::InProgress || voting_deadline <= env.block.time {
+        return Err(StdError::unauthorized())
     }
 
     // Get proposal voting state
@@ -269,27 +300,39 @@ pub fn try_trigger_admin_command<S: Storage, A: Api, Q: Querier>(
         target,
         msg: Binary::from(finished_command.as_bytes()),
         description,
-        due_date: 0,
-        is_admin_command: true,
-        vote_status: ProposalStatus::AdminRequested,
-        run_status: match try_execute_msg(target_contract, Binary::from(finished_command.as_bytes())) {
-            Ok(executed_msg) => {
-                messages.push(executed_msg);
-                Some(Success)
-            },
-            Err(_) => Some(Failure)
-        },
     };
 
     // Store the proposal
     proposal_w(&mut deps.storage).save(proposal_id.to_string().as_bytes(), &proposal)?;
-
+    proposal_funding_deadline_w(&mut deps.storage).save(
+        proposal_id.to_string().as_bytes(),
+        &env.block.time
+    )?;
+    proposal_voting_deadline_w(&mut deps.storage).save(
+        proposal_id.to_string().as_bytes(),
+        &env.block.time
+    )?;
+    proposal_status_w(&mut deps.storage).save(
+        proposal_id.to_string().as_bytes(),
+        &ProposalStatus::AdminRequested
+    )?;
+    let run_status = match try_execute_msg(target_contract, Binary::from(finished_command.as_bytes())) {
+        Ok(executed_msg) => {
+            messages.push(executed_msg);
+            Success
+        },
+        Err(_) => Failure
+    };
+    proposal_run_status_w(&mut deps.storage).save(
+        proposal_id.to_string().as_bytes(),
+        &run_status
+    )?;
 
     Ok(HandleResponse {
         messages,
         log: vec![],
         data: Some( to_binary( &HandleAnswer::TriggerAdminCommand {
-            status: proposal.run_status.unwrap(),
+            status: run_status,
             proposal_id
         })?),
     })
@@ -311,7 +354,7 @@ pub fn try_create_proposal<S: Storage, A: Api, Q: Querier>(
         messages: vec![],
         log: vec![],
         data: Some( to_binary( &HandleAnswer::CreateProposal {
-            status: ResponseStatus::Success,
+            status: Success,
             proposal_id
         })?),
     })
@@ -323,6 +366,8 @@ pub fn try_update_config<S: Storage, A: Api, Q: Querier>(
     admin: Option<HumanAddr>,
     staker: Option<Contract>,
     proposal_deadline: Option<u64>,
+    funding_amount: Option<Uint128>,
+    funding_deadline: Option<u64>,
     minimum_votes: Option<Uint128>,
 ) -> StdResult<HandleResponse> {
 
@@ -339,7 +384,13 @@ pub fn try_update_config<S: Storage, A: Api, Q: Querier>(
             state.staker = staker;
         }
         if let Some(proposal_deadline) = proposal_deadline {
-            state.proposal_deadline = proposal_deadline;
+            state.voting_deadline = proposal_deadline;
+        }
+        if let Some(funding_amount) = funding_amount {
+            state.funding_amount = funding_amount;
+        }
+        if let Some(funding_deadline) = funding_deadline {
+            state.funding_deadline = funding_deadline;
         }
         if let Some(minimum_votes) = minimum_votes {
             state.minimum_votes = minimum_votes;
@@ -352,7 +403,7 @@ pub fn try_update_config<S: Storage, A: Api, Q: Querier>(
         messages: vec![],
         log: vec![],
         data: Some( to_binary( &HandleAnswer::UpdateConfig {
-            status: ResponseStatus::Success
+            status: Success
         })?),
     })
 }
@@ -371,7 +422,7 @@ pub fn try_disable_staker<S: Storage, A: Api, Q: Querier>(
         messages: vec![],
         log: vec![],
         data: Some( to_binary( &HandleAnswer::DisableStaker {
-            status: ResponseStatus::Success
+            status: Success
         })?),
     })
 }
@@ -411,7 +462,7 @@ pub fn try_add_supported_contract<S: Storage, A: Api, Q: Querier>(
         messages: vec![],
         log: vec![],
         data: Some( to_binary( &HandleAnswer::AddSupportedContract {
-            status: ResponseStatus::Success
+            status: Success
         })?),
     })
 }
@@ -445,7 +496,7 @@ pub fn try_remove_supported_contract<S: Storage, A: Api, Q: Querier>(
         messages: vec![],
         log: vec![],
         data: Some( to_binary( &HandleAnswer::RemoveSupportedContract {
-            status: ResponseStatus::Success
+            status: Success
         })?),
     })
 }
@@ -471,7 +522,7 @@ pub fn try_update_supported_contract<S: Storage, A: Api, Q: Querier>(
         messages: vec![],
         log: vec![],
         data: Some( to_binary( &HandleAnswer::UpdateSupportedContract {
-            status: ResponseStatus::Success
+            status: Success
         })?),
     })
 }
@@ -509,7 +560,7 @@ pub fn try_add_admin_command<S: Storage, A: Api, Q: Querier>(
         messages: vec![],
         log: vec![],
         data: Some( to_binary( &HandleAnswer::AddAdminCommand {
-            status: ResponseStatus::Success
+            status: Success
         })?),
     })
 }
@@ -538,7 +589,7 @@ pub fn try_remove_admin_command<S: Storage, A: Api, Q: Querier>(
         messages: vec![],
         log: vec![],
         data: Some( to_binary( &HandleAnswer::RemoveAdminCommand {
-            status: ResponseStatus::Success
+            status: Success
         })?),
     })
 }
@@ -567,7 +618,7 @@ pub fn try_update_admin_command<S: Storage, A: Api, Q: Querier>(
         messages: vec![],
         log: vec![],
         data: Some( to_binary( &HandleAnswer::UpdateAdminCommand {
-            status: ResponseStatus::Success
+            status: Success
         })?),
     })
 }

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod contract;
 pub mod state;
+pub mod proposal_state;
 pub mod handle;
 pub mod query;
 

--- a/contracts/governance/src/proposal_state.rs
+++ b/contracts/governance/src/proposal_state.rs
@@ -4,6 +4,7 @@ use shade_protocol::{
     governance::{Proposal, ProposalStatus, VoteTally},
     generic_response::ResponseStatus,
 };
+use secret_toolkit::snip20::batch::SendAction;
 
 // Proposals
 pub static PROPOSAL_KEY: &[u8] = b"proposals";
@@ -12,6 +13,7 @@ pub static PROPOSAL_FUNDING_DEADLINE_KEY: &[u8] = b"proposal_funding_deadline_ke
 pub static PROPOSAL_STATUS_KEY: &[u8] = b"proposal_status_key";
 pub static PROPOSAL_RUN_KEY: &[u8] = b"proposal_run_key";
 pub static PROPOSAL_FUNDING_KEY: &[u8] = b"proposal_funding_key";
+pub static PROPOSAL_FUNDING_BATCH_KEY: &[u8] = b"proposal_funding_batch_key";
 pub static PROPOSAL_VOTES_KEY: &str = "proposal_votes";
 pub static TOTAL_PROPOSAL_VOTES_KEY: &[u8] = b"total_proposal_votes";
 pub static TOTAL_PROPOSAL_KEY: &[u8] = b"total_proposals";
@@ -68,6 +70,15 @@ pub fn proposal_funding_r<S: Storage>(storage: & S) -> ReadonlyBucket<S, Uint128
 
 pub fn proposal_funding_w<S: Storage>(storage: &mut S) -> Bucket<S, Uint128> {
     bucket(PROPOSAL_FUNDING_KEY, storage)
+}
+
+// Proposal funding batch
+pub fn proposal_funding_batch_r<S: Storage>(storage: & S) -> ReadonlyBucket<S, Vec<SendAction>> {
+    bucket_read(PROPOSAL_FUNDING_BATCH_KEY, storage)
+}
+
+pub fn proposal_funding_batch_w<S: Storage>(storage: &mut S) -> Bucket<S, Vec<SendAction>> {
+    bucket(PROPOSAL_FUNDING_BATCH_KEY, storage)
 }
 
 // Proposal run status - will be available after proposal is run

--- a/contracts/governance/src/proposal_state.rs
+++ b/contracts/governance/src/proposal_state.rs
@@ -1,0 +1,98 @@
+use cosmwasm_std::{Storage, Uint128};
+use cosmwasm_storage::{singleton, singleton_read, ReadonlySingleton, Singleton, bucket, Bucket, bucket_read, ReadonlyBucket};
+use shade_protocol::{
+    governance::{Proposal, ProposalStatus, VoteTally},
+    generic_response::ResponseStatus,
+};
+
+// Proposals
+pub static PROPOSAL_KEY: &[u8] = b"proposals";
+pub static PROPOSAL_VOTE_DEADLINE_KEY: &[u8] = b"proposal_vote_deadline_key";
+pub static PROPOSAL_FUNDING_DEADLINE_KEY: &[u8] = b"proposal_funding_deadline_key";
+pub static PROPOSAL_STATUS_KEY: &[u8] = b"proposal_status_key";
+pub static PROPOSAL_RUN_KEY: &[u8] = b"proposal_run_key";
+pub static PROPOSAL_FUNDING_KEY: &[u8] = b"proposal_funding_key";
+pub static PROPOSAL_VOTES_KEY: &str = "proposal_votes";
+pub static TOTAL_PROPOSAL_VOTES_KEY: &[u8] = b"total_proposal_votes";
+pub static TOTAL_PROPOSAL_KEY: &[u8] = b"total_proposals";
+
+// Total proposal counter
+pub fn total_proposals_w<S: Storage>(storage: &mut S) -> Singleton<S, Uint128> {
+    singleton(storage, TOTAL_PROPOSAL_KEY)
+}
+
+pub fn total_proposals_r<S: Storage>(storage: &S) -> ReadonlySingleton<S, Uint128> {
+    singleton_read(storage, TOTAL_PROPOSAL_KEY)
+}
+
+// Individual proposals
+pub fn proposal_r<S: Storage>(storage: & S) -> ReadonlyBucket<S, Proposal> {
+    bucket_read(PROPOSAL_KEY, storage)
+}
+
+pub fn proposal_w<S: Storage>(storage: &mut S) -> Bucket<S, Proposal> {
+    bucket(PROPOSAL_KEY, storage)
+}
+
+// Proposal funding deadline
+pub fn proposal_funding_deadline_r<S: Storage>(storage: & S) -> ReadonlyBucket<S, u64> {
+    bucket_read(PROPOSAL_FUNDING_DEADLINE_KEY, storage)
+}
+
+pub fn proposal_funding_deadline_w<S: Storage>(storage: &mut S) -> Bucket<S, u64> {
+    bucket(PROPOSAL_FUNDING_DEADLINE_KEY, storage)
+}
+
+// Proposal voting deadline
+pub fn proposal_voting_deadline_r<S: Storage>(storage: & S) -> ReadonlyBucket<S, u64> {
+    bucket_read(PROPOSAL_VOTE_DEADLINE_KEY, storage)
+}
+
+pub fn proposal_voting_deadline_w<S: Storage>(storage: &mut S) -> Bucket<S, u64> {
+    bucket(PROPOSAL_VOTE_DEADLINE_KEY, storage)
+}
+
+// Proposal status
+pub fn proposal_status_r<S: Storage>(storage: & S) -> ReadonlyBucket<S, ProposalStatus> {
+    bucket_read(PROPOSAL_STATUS_KEY, storage)
+}
+
+pub fn proposal_status_w<S: Storage>(storage: &mut S) -> Bucket<S, ProposalStatus> {
+    bucket(PROPOSAL_STATUS_KEY, storage)
+}
+
+// Proposal total funding
+pub fn proposal_funding_r<S: Storage>(storage: & S) -> ReadonlyBucket<S, Uint128> {
+    bucket_read(PROPOSAL_FUNDING_KEY, storage)
+}
+
+pub fn proposal_funding_w<S: Storage>(storage: &mut S) -> Bucket<S, Uint128> {
+    bucket(PROPOSAL_FUNDING_KEY, storage)
+}
+
+// Proposal run status - will be available after proposal is run
+pub fn proposal_run_status_r<S: Storage>(storage: & S) -> ReadonlyBucket<S, ResponseStatus> {
+    bucket_read(PROPOSAL_RUN_KEY, storage)
+}
+
+pub fn proposal_run_status_w<S: Storage>(storage: &mut S) -> Bucket<S, ResponseStatus> {
+    bucket(PROPOSAL_RUN_KEY, storage)
+}
+
+// Individual proposal user votes
+pub fn proposal_votes_r<S: Storage>(storage: & S, proposal: Uint128) -> ReadonlyBucket<S, VoteTally> {
+    bucket_read((proposal.to_string() + PROPOSAL_VOTES_KEY).as_bytes(), storage)
+}
+
+pub fn proposal_votes_w<S: Storage>(storage: &mut S, proposal: Uint128) -> Bucket<S, VoteTally> {
+    bucket((proposal.to_string() + PROPOSAL_VOTES_KEY).as_bytes(), storage)
+}
+
+// Total proposal votes
+pub fn total_proposal_votes_r<S: Storage>(storage: & S) -> ReadonlyBucket<S, VoteTally> {
+    bucket_read(TOTAL_PROPOSAL_VOTES_KEY, storage)
+}
+
+pub fn total_proposal_votes_w<S: Storage>(storage: &mut S) -> Bucket<S, VoteTally> {
+    bucket(TOTAL_PROPOSAL_VOTES_KEY, storage)
+}

--- a/contracts/governance/src/query.rs
+++ b/contracts/governance/src/query.rs
@@ -1,13 +1,42 @@
 use cosmwasm_std::{Api, Extern, Querier, StdError, StdResult, Storage, Uint128};
-use shade_protocol::governance::{QueryAnswer, Proposal};
-use crate::state::{total_proposals_r, proposal_r, supported_contracts_list_r, admin_commands_list_r, supported_contract_r, admin_commands_r, total_proposal_votes_r};
+use shade_protocol::governance::{QueryAnswer, Proposal, QueriedProposal};
+
+use crate::{
+    proposal_state::{
+        total_proposals_r, proposal_r, total_proposal_votes_r, proposal_funding_deadline_r,
+        proposal_voting_deadline_r, proposal_funding_r, proposal_run_status_r, proposal_status_r
+    },
+    state::{
+        supported_contracts_list_r, admin_commands_list_r, supported_contract_r, admin_commands_r
+    }
+};
+
+fn build_proposal<S: Storage, A: Api, Q: Querier>(
+    deps: &Extern<S, A, Q>,
+    proposal_id: Uint128) -> StdResult<QueriedProposal> {
+
+    let proposal = proposal_r(&deps.storage).load(proposal_id.to_string().as_bytes())?;
+
+
+    Ok(QueriedProposal{
+        id: proposal.id,
+        target: proposal.target,
+        msg: proposal.msg,
+        description: proposal.description,
+        funding_deadline: proposal_funding_deadline_r(&deps.storage).load(proposal_id.to_string().as_bytes())?,
+        voting_deadline: proposal_voting_deadline_r(&deps.storage).may_load(proposal_id.to_string().as_bytes())?,
+        total_funding: proposal_funding_r(&deps.storage).load(proposal_id.to_string().as_bytes())?,
+        status: proposal_status_r(&deps.storage).load(proposal_id.to_string().as_bytes())?,
+        run_status: proposal_run_status_r(&deps.storage).may_load(proposal_id.to_string().as_bytes())?
+    })
+}
 
 pub fn proposals<S: Storage, A: Api, Q: Querier>(
     deps: &Extern<S, A, Q>,
     total: Uint128,
     start: Uint128) -> StdResult<QueryAnswer> {
 
-    let mut proposals: Vec<Proposal> = vec![];
+    let mut proposals: Vec<QueriedProposal> = vec![];
 
     let max = total_proposals_r(&deps.storage).load()?;
 
@@ -18,7 +47,7 @@ pub fn proposals<S: Storage, A: Api, Q: Querier>(
     let clamped_start = start.max(Uint128(1));
 
     for i in clamped_start.u128()..((total+clamped_start).min(max).u128() + 1) {
-        proposals.push(proposal_r(&deps.storage).load(Uint128(i).to_string().as_bytes())?)
+        proposals.push(build_proposal(&deps, Uint128(i))?)
     }
 
     Ok(QueryAnswer::Proposals { proposals })
@@ -29,7 +58,7 @@ pub fn proposal<S: Storage, A: Api, Q: Querier>(
     proposal_id: Uint128) -> StdResult<QueryAnswer> {
 
     Ok(QueryAnswer::Proposal {
-        proposal: proposal_r(&deps.storage).load(proposal_id.to_string().as_bytes())?
+        proposal: build_proposal(&deps, proposal_id)?
     })
 }
 

--- a/contracts/governance/src/state.rs
+++ b/contracts/governance/src/state.rs
@@ -7,12 +7,10 @@ use shade_protocol::{
 use shade_protocol::governance::{AdminCommand, UserVote, VoteTally};
 
 pub static CONFIG_KEY: &[u8] = b"config";
+// Saved contracts
 pub static CONTRACT_KEY: &[u8] = b"supported_contracts";
 pub static CONTRACT_LIST_KEY: &[u8] = b"supported_contracts_list";
-pub static PROPOSAL_KEY: &[u8] = b"proposals";
-pub static PROPOSAL_VOTES_KEY: &str = "proposal_votes";
-pub static TOTAL_PROPOSAL_VOTES_KEY: &[u8] = b"total_proposal_votes";
-pub static TOTAL_PROPOSAL_KEY: &[u8] = b"total_proposals";
+// Admin commands
 pub static ADMIN_COMMANDS_KEY: &[u8] = b"admin_commands";
 pub static ADMIN_COMMANDS_LIST_KEY: &[u8] = b"admin_commands_list";
 
@@ -24,39 +22,7 @@ pub fn config_r<S: Storage>(storage: &S) -> ReadonlySingleton<S, Config> {
     singleton_read(storage, CONFIG_KEY)
 }
 
-// Allows to to keep track of total proposals in an easier manner
-pub fn total_proposals_w<S: Storage>(storage: &mut S) -> Singleton<S, Uint128> {
-    singleton(storage, TOTAL_PROPOSAL_KEY)
-}
-
-pub fn total_proposals_r<S: Storage>(storage: &S) -> ReadonlySingleton<S, Uint128> {
-    singleton_read(storage, TOTAL_PROPOSAL_KEY)
-}
-
-pub fn proposal_r<S: Storage>(storage: & S) -> ReadonlyBucket<S, Proposal> {
-    bucket_read(PROPOSAL_KEY, storage)
-}
-
-pub fn proposal_w<S: Storage>(storage: &mut S) -> Bucket<S, Proposal> {
-    bucket(PROPOSAL_KEY, storage)
-}
-
-// Adds the proposal ID to have better range
-pub fn proposal_votes_r<S: Storage>(storage: & S, proposal: Uint128) -> ReadonlyBucket<S, VoteTally> {
-    bucket_read((proposal.to_string() + PROPOSAL_VOTES_KEY).as_bytes(), storage)
-}
-
-pub fn proposal_votes_w<S: Storage>(storage: &mut S, proposal: Uint128) -> Bucket<S, VoteTally> {
-    bucket((proposal.to_string() + PROPOSAL_VOTES_KEY).as_bytes(), storage)
-}
-
-pub fn total_proposal_votes_r<S: Storage>(storage: & S) -> ReadonlyBucket<S, VoteTally> {
-    bucket_read(TOTAL_PROPOSAL_VOTES_KEY, storage)
-}
-
-pub fn total_proposal_votes_w<S: Storage>(storage: &mut S) -> Bucket<S, VoteTally> {
-    bucket(TOTAL_PROPOSAL_VOTES_KEY, storage)
-}
+// Supported contracts
 
 pub fn supported_contract_r<S: Storage>(storage: & S) -> ReadonlyBucket<S, Contract> {
     bucket_read(CONTRACT_KEY, storage)
@@ -73,6 +39,8 @@ pub fn supported_contracts_list_w<S: Storage>(storage: &mut S) -> Singleton<S, V
 pub fn supported_contracts_list_r<S: Storage>(storage: &S) -> ReadonlySingleton<S, Vec<String>> {
     singleton_read(storage, CONTRACT_LIST_KEY)
 }
+
+// Admin commands
 
 pub fn admin_commands_r<S: Storage>(storage: & S) -> ReadonlyBucket<S, AdminCommand> {
     bucket_read(ADMIN_COMMANDS_KEY, storage)

--- a/packages/network_integration/src/contract_helpers/initializer.rs
+++ b/packages/network_integration/src/contract_helpers/initializer.rs
@@ -11,7 +11,7 @@ use secretcli::{cli_types::NetContract,
 use secretcli::secretcli::list_contracts_by_code;
 
 pub fn initialize_initializer(
-    governance: &NetContract, sSCRT: &NetContract, account: String) -> Result<()> {
+    admin: &String, sSCRT: &NetContract, account: &String) -> Result<(NetContract, NetContract, NetContract)> {
     print_header("Initializing Initializer");
     let mut shade = NetContract {
         label: generate_label(8),
@@ -32,14 +32,14 @@ pub fn initialize_initializer(
         snip20_code_hash: sSCRT.code_hash.clone(),
         shade: Snip20ContractInfo {
             label: shade.label.clone(),
-            admin: Some(HumanAddr::from(governance.address.clone())),
+            admin: Some(HumanAddr::from(admin.clone())),
             prng_seed: Default::default(),
             initial_balances: Some(vec![InitialBalance{
                 address: HumanAddr::from(account.clone()), amount: Uint128(10000000) }])
         },
         silk: Snip20ContractInfo {
             label: silk.label.clone(),
-            admin: Some(HumanAddr::from(governance.address.clone())),
+            admin: Some(HumanAddr::from(admin.clone())),
             prng_seed: Default::default(),
             initial_balances: None
         }
@@ -55,13 +55,13 @@ pub fn initialize_initializer(
     let contracts = list_contracts_by_code(sSCRT.id.clone())?;
 
     for contract in contracts {
-        if &contract.label == &shade.label {
+        if contract.label == shade.label {
             print_warning("Found Shade");
             shade.id = contract.code_id.to_string();
             shade.address = contract.address;
             print_contract(&shade);
         }
-        else if &contract.label == &silk.label {
+        else if contract.label == silk.label {
             print_warning("Found Silk");
             silk.id = contract.code_id.to_string();
             silk.address = contract.address;
@@ -92,10 +92,5 @@ pub fn initialize_initializer(
 
     println!("\tTotal silk: {}", get_balance(&silk, account.clone()));
 
-    // Add contracts
-    add_contract("initializer".to_string(), &initializer, &governance)?;
-    add_contract("shade".to_string(), &shade, &governance)?;
-    add_contract("silk".to_string(), &silk, &governance)?;
-
-    Ok(())
+    Ok((initializer, shade, silk))
 }

--- a/packages/shade_protocol/src/governance.rs
+++ b/packages/shade_protocol/src/governance.rs
@@ -18,8 +18,14 @@ pub struct Config {
     pub admin: HumanAddr,
     // Staking contract - optional to support admin only
     pub staker: Option<Contract>,
-    // The amount of time given for each proposal
-    pub proposal_deadline: u64,
+    // The token allowed for funding
+    pub funding_token: Contract,
+    // The amount required to fund a proposal
+    pub funding_amount: Uint128,
+    // Proposal funding period deadline
+    pub funding_deadline: u64,
+    // Proposal voting period deadline
+    pub voting_deadline: u64,
     // The minimum total amount of votes needed to approve deadline
     pub minimum_votes: Uint128,
 }
@@ -34,33 +40,45 @@ pub struct AdminCommand {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct Proposal {
+    // Proposal ID
+    pub id: Uint128,
+    // Target smart contract
+    pub target: String,
+    // Message to execute
+    pub msg: Binary,
+    // Description of proposal
+    pub description: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct QueriedProposal {
     pub id: Uint128,
     pub target: String,
     pub msg: Binary,
     pub description: String,
-    pub due_date: u64,
-    // Used to determine if community voted for it
-    pub is_admin_command: bool,
-    pub vote_status: ProposalStatus,
-    // This will be available after proposal is run
-    pub run_status: Option<ResponseStatus>
+    pub funding_deadline: u64,
+    pub voting_deadline: Option<u64>,
+    pub total_funding: Uint128,
+    pub status: ProposalStatus,
+    pub run_status: Option<ResponseStatus>,
 }
-//TODO: move vote status to its own store
-//TODO: move run status to its own store
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ProposalStatus {
     // Admin command called
     AdminRequested,
-    // Voting not finished
+    // In funding period
+    Funding,
+    // Voting in progress
     InProgress,
     // Total votes did not reach minimum total votes
     Expired,
     // Majority voted No
     Rejected,
     // Majority votes yes
-    Accepted,
+    Passed,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -92,7 +110,10 @@ pub struct UserVote {
 pub struct InitMsg {
     pub admin: Option<HumanAddr>,
     pub staker: Option<Contract>,
-    pub proposal_deadline: u64,
+    pub funding_token: Contract,
+    pub funding_amount: Uint128,
+    pub funding_deadline: u64,
+    pub voting_deadline: u64,
     pub quorum: Uint128,
 }
 
@@ -111,6 +132,7 @@ pub enum HandleMsg {
         proposal: String,
         description: String,
     },
+    //TODO: add receive to send money
 
     /// Admin Command
     /// These commands can be run by admins any time
@@ -137,6 +159,8 @@ pub enum HandleMsg {
         admin: Option<HumanAddr>,
         staker: Option<Contract>,
         proposal_deadline: Option<u64>,
+        funding_amount: Option<Uint128>,
+        funding_deadline: Option<u64>,
         minimum_votes: Option<Uint128>,
     },
 
@@ -195,9 +219,11 @@ pub enum HandleAnswer {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
+// TODO: RETURNED PROPOSAL INFO NEEDS TO BE FIXED
 pub enum QueryMsg {
     GetProposalVotes { proposal_id: Uint128 },
-    GetProposals { total: Uint128, start: Uint128 },
+    //TODO: IMPLEMENT THE STATUS FLAG
+    GetProposals { total: Uint128, start: Uint128, status: Option<ProposalStatus> },
     GetProposal { proposal_id: Uint128 },
     GetTotalProposals {},
     GetSupportedContracts {},
@@ -214,8 +240,8 @@ impl Query for QueryMsg {
 #[serde(rename_all = "snake_case")]
 pub enum QueryAnswer {
     ProposalVotes { status: VoteTally },
-    Proposals { proposals: Vec<Proposal> },
-    Proposal { proposal: Proposal },
+    Proposals { proposals: Vec<QueriedProposal> },
+    Proposal { proposal: QueriedProposal },
     TotalProposals { total: Uint128 },
     SupportedContracts { contracts: Vec<String> },
     SupportedContract { contract: Contract },

--- a/packages/shade_protocol/src/governance.rs
+++ b/packages/shade_protocol/src/governance.rs
@@ -72,7 +72,7 @@ pub enum ProposalStatus {
     // In funding period
     Funding,
     // Voting in progress
-    InProgress,
+    Voting,
     // Total votes did not reach minimum total votes
     Expired,
     // Majority voted No
@@ -132,7 +132,14 @@ pub enum HandleMsg {
         proposal: String,
         description: String,
     },
-    //TODO: add receive to send money
+
+    /// Proposal funding
+    Receive {
+        sender: HumanAddr,
+        amount: Uint128,
+        // Proposal ID
+        msg: Option<Binary>,
+    },
 
     /// Admin Command
     /// These commands can be run by admins any time
@@ -204,6 +211,7 @@ impl HandleCallback for HandleMsg {
 #[serde(rename_all = "snake_case")]
 pub enum HandleAnswer {
     CreateProposal { status: ResponseStatus, proposal_id: Uint128 },
+    FundProposal { status: ResponseStatus, total_funding: Uint128 },
     AddAdminCommand { status: ResponseStatus },
     RemoveAdminCommand { status: ResponseStatus },
     UpdateAdminCommand { status: ResponseStatus },

--- a/packages/shade_protocol/src/snip20.rs
+++ b/packages/shade_protocol/src/snip20.rs
@@ -98,6 +98,10 @@ pub struct InitConfig {
 #[derive(Serialize, Deserialize, JsonSchema, Clone, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum HandleMsg {
+    ChangeAdmin {
+        address: HumanAddr,
+        padding: Option<String>,
+    },
     // Native coin interactions
     Redeem {
         amount: Uint128,


### PR DESCRIPTION
Added proposal funding period to limit proposal spamming. The created proposals are placed in a funding period much like the voting period where users must fund and reach a certain limit, if that limit is reached before the funding deadline the proposal will go into a voting period and return all of the funds to their respective users, if the limit is not reached then it will be sent to treasury (currently not implemented since im waiting for treasury funding handles)

Another thing that was added was more efficient storage for proposal related information, for example votes, amounts, deadlines and status are in their respective storages, this allows for cheaper serialization/deserialization.