### PR TITLE
Secret Network Upgrade

### DIFF
--- a/contracts/airdrop/Cargo.toml
+++ b/contracts/airdrop/Cargo.toml
@@ -22,13 +22,13 @@ default = []
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]
-debug-print = ["cosmwasm-std/debug-print"]
+#debug-print = ["cosmwasm-std/debug-print"]
 
 [dependencies]
-cosmwasm-schema = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-cosmwasm-storage = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-secret-toolkit = { git = "https://github.com/enigmampc/secret-toolkit", branch = "debug-print"}
+cosmwasm-schema = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
+cosmwasm-storage = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
+secret-toolkit = { git = "https://github.com/scrtlabs/secret-toolkit" }
 shade-protocol = { version = "0.1.0", path = "../../packages/shade_protocol" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/governance/Cargo.toml
+++ b/contracts/governance/Cargo.toml
@@ -20,13 +20,12 @@ default = []
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]
-debug-print = ["cosmwasm-std/debug-print"]
+#debug-print = ["cosmwasm-std/debug-print"]
 
 [dependencies]
-cosmwasm-schema = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-cosmwasm-storage = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-# TODO: Update when secret-toolkit accepts the branch
+cosmwasm-schema = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
+cosmwasm-storage = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
 secret-toolkit = { git = "https://github.com/FloppyDisck/secret-toolkit", branch = "snip20-batch-transactions"}
 shade-protocol = { version = "0.1.0", path = "../../packages/shade_protocol" }
 schemars = "0.7"

--- a/contracts/initializer/Cargo.toml
+++ b/contracts/initializer/Cargo.toml
@@ -20,13 +20,13 @@ default = []
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]
-debug-print = ["cosmwasm-std/debug-print"]
+#debug-print = ["cosmwasm-std/debug-print"]
 
 [dependencies]
-cosmwasm-schema = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-cosmwasm-storage = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-secret-toolkit = { git = "https://github.com/enigmampc/secret-toolkit", branch = "debug-print"}
+cosmwasm-schema = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
+cosmwasm-storage = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
+secret-toolkit = { git = "https://github.com/scrtlabs/secret-toolkit" }
 shade-protocol = { version = "0.1.0", path = "../../packages/shade_protocol" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/micro_mint/Cargo.toml
+++ b/contracts/micro_mint/Cargo.toml
@@ -23,13 +23,13 @@ default = []
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]
-debug-print = ["cosmwasm-std/debug-print"]
+#debug-print = ["cosmwasm-std/debug-print"]
 
 [dependencies]
-cosmwasm-schema = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-cosmwasm-storage = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-secret-toolkit = { git = "https://github.com/enigmampc/secret-toolkit", branch = "debug-print"}
+cosmwasm-schema = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
+cosmwasm-storage = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
+secret-toolkit = { git = "https://github.com/scrtlabs/secret-toolkit" }
 shade-protocol = { version = "0.1.0", path = "../../packages/shade_protocol" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/mint/Cargo.toml
+++ b/contracts/mint/Cargo.toml
@@ -20,13 +20,13 @@ default = []
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]
-debug-print = ["cosmwasm-std/debug-print"]
+#debug-print = ["cosmwasm-std/debug-print"]
 
 [dependencies]
-cosmwasm-schema = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-cosmwasm-storage = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-secret-toolkit = { git = "https://github.com/enigmampc/secret-toolkit", branch = "debug-print"}
+cosmwasm-schema = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
+cosmwasm-storage = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
+secret-toolkit = { git = "https://github.com/scrtlabs/secret-toolkit" }
 shade-protocol = { version = "0.1.0", path = "../../packages/shade_protocol" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/mock_band/Cargo.toml
+++ b/contracts/mock_band/Cargo.toml
@@ -20,14 +20,14 @@ default = []
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]
-debug-print = ["cosmwasm-std/debug-print"]
+#debug-print = ["cosmwasm-std/debug-print"]
 
 [dependencies]
 bincode = "1.3.1"
-cosmwasm-schema = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-cosmwasm-storage = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-secret-toolkit = { git = "https://github.com/enigmampc/secret-toolkit", branch = "debug-print"}
+cosmwasm-schema = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
+cosmwasm-storage = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
+secret-toolkit = { git = "https://github.com/scrtlabs/secret-toolkit" }
 shade-protocol = { version = "0.1.0", path = "../../packages/shade_protocol" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/oracle/Cargo.toml
+++ b/contracts/oracle/Cargo.toml
@@ -23,14 +23,14 @@ default = []
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]
-debug-print = ["cosmwasm-std/debug-print"]
+#debug-print = ["cosmwasm-std/debug-print"]
 
 [dependencies]
 bincode = "1.3.1"
-cosmwasm-schema = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-cosmwasm-storage = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-secret-toolkit = { git = "https://github.com/enigmampc/secret-toolkit", branch = "debug-print"}
+cosmwasm-schema = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
+cosmwasm-storage = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
+secret-toolkit = { git = "https://github.com/scrtlabs/secret-toolkit" }
 shade-protocol = { version = "0.1.0", path = "../../packages/shade_protocol" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/scrt_staking/Cargo.toml
+++ b/contracts/scrt_staking/Cargo.toml
@@ -20,14 +20,13 @@ default = []
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]
-debug-print = ["cosmwasm-std/debug-print"]
+#debug-print = ["cosmwasm-std/debug-print"]
 
 [dependencies]
-cosmwasm-schema = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print", features = ["staking"] }
-
-cosmwasm-storage = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-secret-toolkit = { git = "https://github.com/enigmampc/secret-toolkit", branch = "debug-print"}
+cosmwasm-schema = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
+cosmwasm-storage = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
+secret-toolkit = { git = "https://github.com/scrtlabs/secret-toolkit" }
 shade-protocol = { version = "0.1.0", path = "../../packages/shade_protocol" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/staking/Cargo.toml
+++ b/contracts/staking/Cargo.toml
@@ -20,13 +20,13 @@ default = []
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]
-debug-print = ["cosmwasm-std/debug-print"]
+#debug-print = ["cosmwasm-std/debug-print"]
 
 [dependencies]
-cosmwasm-schema = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-cosmwasm-storage = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-secret-toolkit = { git = "https://github.com/enigmampc/secret-toolkit", branch = "debug-print"}
+cosmwasm-schema = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
+cosmwasm-storage = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
+secret-toolkit = { git = "https://github.com/scrtlabs/secret-toolkit" }
 shade-protocol = { version = "0.1.0", path = "../../packages/shade_protocol" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/treasury/Cargo.toml
+++ b/contracts/treasury/Cargo.toml
@@ -20,13 +20,13 @@ default = []
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]
-debug-print = ["cosmwasm-std/debug-print"]
+#debug-print = ["cosmwasm-std/debug-print"]
 
 [dependencies]
-cosmwasm-schema = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-cosmwasm-storage = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-secret-toolkit = { git = "https://github.com/enigmampc/secret-toolkit", branch = "debug-print"}
+cosmwasm-schema = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
+cosmwasm-storage = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
+secret-toolkit = { git = "https://github.com/scrtlabs/secret-toolkit" }
 shade-protocol = { version = "0.1.0", path = "../../packages/shade_protocol" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/network_integration/Cargo.toml
+++ b/packages/network_integration/Cargo.toml
@@ -12,10 +12,10 @@ default = []
 
 [dependencies]
 colored = "2.0.0"
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
 shade-protocol = { version = "0.1.0", path = "../shade_protocol" }
 secretcli = { version = "0.1.0", path = "../secretcli" }
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.67"}
 getrandom = { version = "0.2", features = ["js"] } # Prevents wasm from freaking out when running make
 rand = { version = "0.8.4"}
-cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }

--- a/packages/shade_protocol/Cargo.toml
+++ b/packages/shade_protocol/Cargo.toml
@@ -15,13 +15,13 @@ default = []
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]
-debug-print = ["cosmwasm-std/debug-print"]
+#debug-print = ["cosmwasm-std/debug-print"]
 
 [dependencies]
-cosmwasm-schema = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-cosmwasm-storage = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.4-debug-print" }
-secret-toolkit = { git = "https://github.com/enigmampc/secret-toolkit", branch = "debug-print"}
+cosmwasm-schema = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
+cosmwasm-storage = { git = "https://github.com/scrtlabs/SecretNetwork", tag = "v1.2.0" }
+secret-toolkit = { git = "https://github.com/scrtlabs/secret-toolkit" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 snafu = { version = "0.6.3" }


### PR DESCRIPTION
I started moving things to SecretNetwork 1.2.0, which uses cosmwasm 0.10. Reuven and Assaf said they will be porting the debug-print feature soon, until then I have it commented out (but its still used in the code at this point). There are still some build issues.