### PR TITLE
Airdrop | minor tweaks

### DIFF
--- a/contracts/airdrop/src/contract.rs
+++ b/contracts/airdrop/src/contract.rs
@@ -5,7 +5,7 @@ use shade_protocol::{
         QueryMsg, Config
     }
 };
-use crate::{state::{config_w, reward_w, claim_status_w},
+use crate::{state::{config_w, reward_w, claim_status_w, user_total_claimed_w, total_claimed_w},
             handle::{try_update_config, try_add_tasks, try_complete_task, try_claim},
             query };
 use shade_protocol::airdrop::RequiredTask;
@@ -55,9 +55,13 @@ pub fn init<S: Storage, A: Api, Q: Querier>(
         let key = reward.address.to_string();
 
         reward_w(&mut deps.storage).save(key.as_bytes(), &reward)?;
+        user_total_claimed_w(&mut deps.storage).save(key.as_bytes(), &Uint128::zero())?;
         // Save the initial claim
         claim_status_w(&mut deps.storage, 0).save(key.as_bytes(), &false)?;
     }
+
+    // Initialize claim amount
+    total_claimed_w(&mut deps.storage).save(&Uint128::zero())?;
 
     Ok(InitResponse {
         messages: vec![],

--- a/contracts/airdrop/src/contract.rs
+++ b/contracts/airdrop/src/contract.rs
@@ -6,7 +6,7 @@ use shade_protocol::{
     }
 };
 use crate::{state::{config_w, reward_w, claim_status_w, user_total_claimed_w, total_claimed_w},
-            handle::{try_update_config, try_add_tasks, try_complete_task, try_claim},
+            handle::{try_update_config, try_add_tasks, try_complete_task, try_claim, try_decay},
             query };
 use shade_protocol::airdrop::RequiredTask;
 
@@ -51,6 +51,7 @@ pub fn init<S: Storage, A: Api, Q: Querier>(
             None => { env.message.sender.clone() }
             Some(admin) => { admin }
         },
+        dump_address: msg.dump_address,
         airdrop_snip20: msg.airdrop_token.clone(),
         airdrop_total,
         task_claim,
@@ -79,13 +80,16 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
 ) -> StdResult<HandleResponse> {
     match msg {
         HandleMsg::UpdateConfig {
-            admin, start_date, end_date
-        } => try_update_config(deps, env, admin, start_date, end_date),
+            admin, dump_address,
+            start_date, end_date
+        } => try_update_config(deps, env, admin, dump_address,
+                               start_date, end_date),
         HandleMsg::AddTasks { tasks
         } => try_add_tasks(deps, &env, tasks),
         HandleMsg::CompleteTask { address
         } => try_complete_task(deps, &env, address),
         HandleMsg::Claim { } => try_claim(deps, &env),
+        HandleMsg::Decay { } => try_decay(deps, &env),
     }
 }
 

--- a/contracts/airdrop/src/handle.rs
+++ b/contracts/airdrop/src/handle.rs
@@ -2,7 +2,7 @@ use cosmwasm_std::{to_binary, Api, Env, Extern, HandleResponse, Querier, StdErro
 use crate::state::{config_r, config_w, reward_r, claim_status_w, claim_status_r, user_total_claimed_w, total_claimed_w};
 use shade_protocol::airdrop::{HandleAnswer, RequiredTask};
 use shade_protocol::generic_response::ResponseStatus;
-use secret_toolkit::snip20::mint_msg;
+use secret_toolkit::snip20::send_msg;
 
 pub fn try_update_config<S: Storage, A: Api, Q: Querier>(
     deps: &mut Extern<S, A, Q>,
@@ -169,8 +169,8 @@ pub fn try_claim<S: Storage, A: Api, Q: Querier>(
     })?;
 
     // Redeem
-    let messages =  vec![mint_msg(user, redeem_amount,
-                                  None, 1,
+    let messages =  vec![send_msg(user, redeem_amount,
+                                  None, None, 0,
                                   config.airdrop_snip20.code_hash,
                                   config.airdrop_snip20.address)?];
 

--- a/contracts/airdrop/src/handle.rs
+++ b/contracts/airdrop/src/handle.rs
@@ -172,14 +172,11 @@ pub fn try_claim<S: Storage, A: Api, Q: Querier>(
         Ok(total_claimed + redeem_amount)
     })?;
 
-    // Redeem
-    let messages =  vec![send_msg(user, redeem_amount,
-                                  None, None, 0,
-                                  config.airdrop_snip20.code_hash,
-                                  config.airdrop_snip20.address)?];
-
     Ok(HandleResponse {
-        messages,
+        messages: vec![send_msg(user, redeem_amount,
+                                None, None, 0,
+                                config.airdrop_snip20.code_hash,
+                                config.airdrop_snip20.address)?],
         log: vec![],
         data: Some( to_binary( &HandleAnswer::Claim {
             status: ResponseStatus::Success } )? )

--- a/contracts/airdrop/src/query.rs
+++ b/contracts/airdrop/src/query.rs
@@ -25,7 +25,7 @@ pub fn airdrop_amount<S: Storage, A: Api, Q: Querier>
     let eligible_amount = reward_r(&deps.storage).load(key.as_bytes())?.amount;
 
     let mut finished_tasks = vec![];
-    let mut claimed = user_total_claimed_r(&deps.storage).load(key.as_bytes())?;
+    let claimed = user_total_claimed_r(&deps.storage).load(key.as_bytes())?;
     let mut unclaimed = Uint128::zero();
 
     let config = config_r(&deps.storage).load()?;

--- a/contracts/airdrop/src/query.rs
+++ b/contracts/airdrop/src/query.rs
@@ -1,11 +1,13 @@
 use cosmwasm_std::{Api, Extern, Querier, StdResult, Storage, HumanAddr, Uint128};
 use shade_protocol::airdrop::{QueryAnswer};
 use crate::{state::{config_r, reward_r}};
-use crate::state::claim_status_r;
+use crate::state::{claim_status_r, total_claimed_r, user_total_claimed_r};
 
 pub fn config<S: Storage, A: Api, Q: Querier>
 (deps: &Extern<S, A, Q>) -> StdResult<QueryAnswer> {
-    Ok(QueryAnswer::Config { config: config_r(&deps.storage).load()?
+    Ok(QueryAnswer::Config {
+        config: config_r(&deps.storage).load()?,
+        total_claimed: total_claimed_r(&deps.storage).load()?,
     })
 }
 
@@ -23,7 +25,7 @@ pub fn airdrop_amount<S: Storage, A: Api, Q: Querier>
     let eligible_amount = reward_r(&deps.storage).load(key.as_bytes())?.amount;
 
     let mut finished_tasks = vec![];
-    let mut claimed = Uint128::zero();
+    let mut claimed = user_total_claimed_r(&deps.storage).load(key.as_bytes())?;
     let mut unclaimed = Uint128::zero();
 
     let config = config_r(&deps.storage).load()?;
@@ -35,8 +37,8 @@ pub fn airdrop_amount<S: Storage, A: Api, Q: Querier>
             let calc = task.percent.multiply_ratio(eligible_amount.clone(),
                                                    Uint128(100));
             match task_claimed {
-                true => claimed += calc,
-                false => unclaimed += calc
+                false => unclaimed += calc,
+                _ => {}
             };
         }
     }

--- a/contracts/airdrop/src/state.rs
+++ b/contracts/airdrop/src/state.rs
@@ -1,9 +1,11 @@
-use cosmwasm_std::Storage;
+use cosmwasm_std::{Storage, Uint128};
 use cosmwasm_storage::{singleton, singleton_read, ReadonlySingleton, Singleton, bucket, Bucket, bucket_read, ReadonlyBucket};
 use shade_protocol::airdrop::{Config, Reward};
 
 pub static CONFIG_KEY: &[u8] = b"config";
 pub static REWARDS_KEY: &[u8] = b"rewards";
+pub static TOTAL_CLAIMED_KEY: &[u8] = b"total_claimed";
+pub static USER_TOTAL_CLAIMED_KEY: &[u8] = b"user_total_claimed";
 
 pub fn config_w<S: Storage>(storage: &mut S) -> Singleton<S, Config> {
     singleton(storage, CONFIG_KEY)
@@ -28,4 +30,22 @@ pub fn claim_status_r<S: Storage>(storage: & S, index: usize) -> ReadonlyBucket<
 
 pub fn claim_status_w<S: Storage>(storage: &mut S, index: usize) -> Bucket<S, bool> {
     bucket(&[index as u8], storage)
+}
+
+// Total claimed
+pub fn total_claimed_r<S: Storage>(storage: &S) -> ReadonlySingleton<S, Uint128> {
+    singleton_read(storage, TOTAL_CLAIMED_KEY)
+}
+
+pub fn total_claimed_w<S: Storage>(storage: &mut S) -> Singleton<S, Uint128> {
+    singleton(storage, TOTAL_CLAIMED_KEY)
+}
+
+// Total user claimed
+pub fn user_total_claimed_r<S: Storage>(storage: & S) -> ReadonlyBucket<S, Uint128> {
+    bucket_read(USER_TOTAL_CLAIMED_KEY, storage)
+}
+
+pub fn user_total_claimed_w<S: Storage>(storage: &mut S) -> Bucket<S, Uint128> {
+    bucket(USER_TOTAL_CLAIMED_KEY, storage)
 }

--- a/packages/network_integration/Cargo.toml
+++ b/packages/network_integration/Cargo.toml
@@ -12,6 +12,7 @@ default = []
 
 [dependencies]
 colored = "2.0.0"
+chrono = "0.4.19"
 shade-protocol = { version = "0.1.0", path = "../shade_protocol" }
 secretcli = { version = "0.1.0", path = "../secretcli" }
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/network_integration/src/contract_helpers/initializer.rs
+++ b/packages/network_integration/src/contract_helpers/initializer.rs
@@ -4,7 +4,6 @@ use shade_protocol::{snip20::{InitialBalance}, snip20,
                      initializer, initializer::Snip20ContractInfo};
 use crate::{utils::{print_header, generate_label, print_contract, print_warning,
                     STORE_GAS, GAS, VIEW_KEY, ACCOUNT_KEY, INITIALIZER_FILE},
-            contract_helpers::governance::add_contract,
             contract_helpers::minter::get_balance};
 use secretcli::{cli_types::NetContract,
                 secretcli::{test_contract_handle, test_inst_init, list_contracts_by_code}};

--- a/packages/network_integration/src/main.rs
+++ b/packages/network_integration/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Network integration test crate")
-}

--- a/packages/network_integration/tests/testnet_integration.rs
+++ b/packages/network_integration/tests/testnet_integration.rs
@@ -1,11 +1,9 @@
 use colored::*;
 use serde_json::Result;
 use cosmwasm_std::{HumanAddr, Uint128, to_binary};
-use secretcli::{cli_types::NetContract,
-                secretcli::{account_address, query_contract, test_contract_handle,
-                            test_inst_init, list_contracts_by_code}};
-use shade_protocol::{snip20::{InitConfig, InitialBalance}, snip20, governance, staking,
-                     micro_mint, band, oracle, asset::Contract, airdrop,
+use secretcli::{secretcli::{account_address, query_contract, test_contract_handle, test_inst_init}};
+use shade_protocol::{snip20::{InitConfig}, snip20, governance, staking,
+                     band, oracle, asset::Contract, airdrop,
                      airdrop::{Reward, RequiredTask},
                      governance::{UserVote, Vote, ProposalStatus}, generic_response::ResponseStatus};
 use network_integration::{utils::{print_header, print_warning, generate_label, print_contract,

--- a/packages/shade_protocol/src/airdrop.rs
+++ b/packages/shade_protocol/src/airdrop.rs
@@ -23,6 +23,8 @@ pub struct Config {
     pub admin: HumanAddr,
     // The snip20 to be minted
     pub airdrop_snip20: Contract,
+    // Total claimable amount
+    pub airdrop_total: Uint128,
     // Required tasks
     pub task_claim: Vec<RequiredTask>,
     // Checks if airdrop has started / ended
@@ -38,7 +40,7 @@ pub struct InitMsg {
     pub start_time: Option<u64>,
     // Can be set to never end
     pub end_time: Option<u64>,
-    // Secret network delegators snapshot
+    // Delegators snapshot
     pub rewards: Vec<Reward>,
     // Default gifted amount
     pub default_claim: Uint128,
@@ -96,8 +98,7 @@ impl Query for QueryMsg {
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryAnswer {
-    // TODO: add total claimed in config
-    Config { config: Config },
+    Config { config: Config, total_claimed: Uint128 },
     Dates { start: u64, end: Option<u64> },
     Eligibility {
         // Total eligible

--- a/packages/shade_protocol/src/airdrop.rs
+++ b/packages/shade_protocol/src/airdrop.rs
@@ -21,6 +21,8 @@ pub struct Reward {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Config {
     pub admin: HumanAddr,
+    // Where the decayed tokens will be dumped, if none then nothing happens
+    pub dump_address: Option<HumanAddr>,
     // The snip20 to be minted
     pub airdrop_snip20: Contract,
     // Total claimable amount
@@ -35,6 +37,8 @@ pub struct Config {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InitMsg {
     pub admin: Option<HumanAddr>,
+    // Where the decayed tokens will be dumped, if none then nothing happens
+    pub dump_address: Option<HumanAddr>,
     pub airdrop_token: Contract,
     // The airdrop time limit
     pub start_time: Option<u64>,
@@ -57,6 +61,7 @@ impl InitCallback for InitMsg {
 pub enum HandleMsg {
     UpdateConfig {
         admin: Option<HumanAddr>,
+        dump_address: Option<HumanAddr>,
         start_date: Option<u64>,
         end_date: Option<u64>,
     },
@@ -66,7 +71,8 @@ pub enum HandleMsg {
     CompleteTask {
         address: HumanAddr
     },
-    Claim {}
+    Claim {},
+    Decay {},
 }
 
 impl HandleCallback for HandleMsg {
@@ -80,7 +86,8 @@ pub enum HandleAnswer {
     UpdateConfig { status: ResponseStatus },
     AddTask { status: ResponseStatus },
     CompleteTask { status: ResponseStatus },
-    Claim { status: ResponseStatus }
+    Claim { status: ResponseStatus },
+    Decay { status: ResponseStatus },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/shade_protocol/src/airdrop.rs
+++ b/packages/shade_protocol/src/airdrop.rs
@@ -96,6 +96,7 @@ impl Query for QueryMsg {
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryAnswer {
+    // TODO: add total claimed in config
     Config { config: Config },
     Dates { start: u64, end: Option<u64> },
     Eligibility {


### PR DESCRIPTION
Added a brute decay where the unclaimed amount gets dumped into the ```dump_address``` once ```end_date``` is reached.
Replaced minting items with sending, the contract will now have to be funded before it can start distributing rewards.
Fixed potential issue regarding token distribution when handling certain amounts with certain task percentages; token division will sometimes create very little uToken to not be claimed, to combat this when a user claims and its total percentage achieved is 100% then we just return the current claimed amount subtracted by the total rewarded amount.

Closes #128, Closes #129, Closes #135