### PR TITLE
[oracle] Unregister Secret Swap pair

### DIFF
--- a/contracts/oracle/src/contract.rs
+++ b/contracts/oracle/src/contract.rs
@@ -59,6 +59,9 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
         HandleMsg::RegisterSswapPair {
             pair,
         } => handle::register_sswap_pair(deps, env, pair),
+        HandleMsg::UnregisterSswapPair {
+            symbol,
+        } => handle::unregister_sswap_pair(deps, env, symbol),
         HandleMsg::RegisterIndex {
             symbol,
             basket,

--- a/contracts/oracle/src/contract.rs
+++ b/contracts/oracle/src/contract.rs
@@ -60,8 +60,8 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
             pair,
         } => handle::register_sswap_pair(deps, env, pair),
         HandleMsg::UnregisterSswapPair {
-            symbol,
-        } => handle::unregister_sswap_pair(deps, env, symbol),
+            pair,
+        } => handle::unregister_sswap_pair(deps, env, pair),
         HandleMsg::RegisterIndex {
             symbol,
             basket,

--- a/contracts/oracle/src/handle.rs
+++ b/contracts/oracle/src/handle.rs
@@ -7,7 +7,8 @@ use cosmwasm_std::{
 use secret_toolkit::{
     utils::Query,
     snip20::{
-        token_info_query, 
+        token_info_query,
+        TokenInfo,
     },
 };
 use shade_protocol::{
@@ -41,32 +42,11 @@ pub fn register_sswap_pair<S: Storage, A: Api, Q: Querier>(
         return Err(StdError::Unauthorized { backtrace: None });
     }
 
-    //Query for snip20's in the pair
-    let response: PairResponse = PairQuery::Pair {}.query(
-        &deps.querier,
-        pair.code_hash.clone(),
-        pair.address.clone(),
+    let (token_contract, token_info) = fetch_token_paired_to_sscrt_on_sswap(
+        deps,
+        config.sscrt.address,
+        &pair
     )?;
-
-    let mut token_contract = Contract {
-        address: response.asset_infos[0].token.contract_addr.clone(),
-        code_hash: response.asset_infos[0].token.token_code_hash.clone(),
-    };
-    // if thats sscrt, switch it
-    if token_contract.address == config.sscrt.address {
-        token_contract = Contract {
-            address: response.asset_infos[1].token.contract_addr.clone(),
-            code_hash: response.asset_infos[1].token.token_code_hash.clone(),
-        }
-    }
-    // if neither is sscrt
-    else if response.asset_infos[1].token.contract_addr != config.sscrt.address {
-        return Err(StdError::NotFound { kind: "Not an SSCRT Pair".to_string(), backtrace: None });
-    }
-
-    let token_info = token_info_query(&deps.querier, 1,
-                      token_contract.code_hash.clone(),
-                      token_contract.address.clone())?;
 
     sswap_pairs_w(&mut deps.storage).save(token_info.symbol.as_bytes(), &SswapPair {
         pair,
@@ -88,7 +68,7 @@ pub fn register_sswap_pair<S: Storage, A: Api, Q: Querier>(
 pub fn unregister_sswap_pair<S: Storage, A: Api, Q: Querier>(
     deps: &mut Extern<S, A, Q>,
     env: Env,
-    symbol: String,
+    pair: Contract,
 ) -> StdResult<HandleResponse> {
 
     let config = config_r(&deps.storage).load()?;
@@ -96,7 +76,13 @@ pub fn unregister_sswap_pair<S: Storage, A: Api, Q: Querier>(
         return Err(StdError::Unauthorized { backtrace: None });
     }
 
-    sswap_pairs_w(&mut deps.storage).remove(symbol.as_bytes());
+    let (_, token_info) = fetch_token_paired_to_sscrt_on_sswap(
+        deps,
+        config.sscrt.address,
+        &pair
+    )?;
+
+    sswap_pairs_w(&mut deps.storage).remove(token_info.symbol.as_bytes());
 
     Ok(HandleResponse {
         messages: vec![],
@@ -104,6 +90,45 @@ pub fn unregister_sswap_pair<S: Storage, A: Api, Q: Querier>(
         data: Some( to_binary( &HandleAnswer::UnregisterSswapPair {
             status: ResponseStatus::Success } )? )
     })
+}
+
+///
+/// Will fetch token Contract along with TokenInfo for {symbol} in pair argument.
+/// Pair argument must represent Secret Swap contract for {symbol}/sSCRT or sSCRT/{symbol}.
+///
+fn fetch_token_paired_to_sscrt_on_sswap<S: Storage, A: Api, Q: Querier>(
+    deps: &mut Extern<S, A, Q>,
+    sscrt_addr: HumanAddr,
+    pair: &Contract,
+) -> StdResult<(Contract, TokenInfo)> {
+    // Query for snip20's in the pair
+    let response: PairResponse = PairQuery::Pair{}.query(
+        &deps.querier,
+        pair.code_hash.clone(),
+        pair.address.clone(),
+    )?;
+
+    let mut token_contract = Contract {
+        address: response.asset_infos[0].token.contract_addr.clone(),
+        code_hash: response.asset_infos[0].token.token_code_hash.clone(),
+    };
+    // if thats sscrt, switch it
+    if token_contract.address == sscrt_addr {
+        token_contract = Contract {
+            address: response.asset_infos[1].token.contract_addr.clone(),
+            code_hash: response.asset_infos[1].token.token_code_hash.clone(),
+        }
+    }
+    // if neither is sscrt
+    else if response.asset_infos[1].token.contract_addr != sscrt_addr {
+        return Err(StdError::NotFound { kind: "Not an SSCRT Pair".to_string(), backtrace: None });
+    }
+
+    let token_info = token_info_query(&deps.querier, 1,
+                                      token_contract.code_hash.clone(),
+                                      token_contract.address.clone())?;
+
+    Ok((token_contract, token_info))
 }
 
 pub fn register_index<S: Storage, A: Api, Q: Querier>(

--- a/contracts/oracle/src/handle.rs
+++ b/contracts/oracle/src/handle.rs
@@ -27,7 +27,7 @@ use shade_protocol::{
 use crate::state::{
     config_w, config_r,
     sswap_pairs_w, sswap_pairs_r,
-    index_w, index_r,
+    index_w,
 };
 
 pub fn register_sswap_pair<S: Storage, A: Api, Q: Querier>(
@@ -83,7 +83,27 @@ pub fn register_sswap_pair<S: Storage, A: Api, Q: Querier>(
         data: Some( to_binary( &HandleAnswer::RegisterSswapPair {
             status: ResponseStatus::Success } )? )
     })
+}
 
+pub fn unregister_sswap_pair<S: Storage, A: Api, Q: Querier>(
+    deps: &mut Extern<S, A, Q>,
+    env: Env,
+    symbol: String,
+) -> StdResult<HandleResponse> {
+
+    let config = config_r(&deps.storage).load()?;
+    if env.message.sender != config.admin {
+        return Err(StdError::Unauthorized { backtrace: None });
+    }
+
+    sswap_pairs_w(&mut deps.storage).remove(symbol.as_bytes());
+
+    Ok(HandleResponse {
+        messages: vec![],
+        log: vec![],
+        data: Some( to_binary( &HandleAnswer::UnregisterSswapPair {
+            status: ResponseStatus::Success } )? )
+    })
 }
 
 pub fn register_index<S: Storage, A: Api, Q: Querier>(

--- a/contracts/oracle/src/query.rs
+++ b/contracts/oracle/src/query.rs
@@ -24,7 +24,6 @@ use shade_protocol::{
 };
 use crate::state::{
     config_r,
-    hard_coded_r,
     sswap_pairs_r,
     index_r,
 };

--- a/contracts/oracle/src/test.rs
+++ b/contracts/oracle/src/test.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
     use crate::query;
-    use cosmwasm_std::testing::{mock_dependencies, mock_env, MockStorage, MockApi, MockQuerier};
+    
     use cosmwasm_std::{Uint128};
 
     macro_rules! normalize_price_tests {

--- a/packages/shade_protocol/src/oracle.rs
+++ b/packages/shade_protocol/src/oracle.rs
@@ -54,7 +54,7 @@ pub enum HandleMsg {
         admin: Option<HumanAddr>,
         band: Option<Contract>,
     },
-    // Register Secret Swap Pair (should be */SCRT)
+    // Register Secret Swap Pair (should be */SCRT or SSCRT/*)
     RegisterSswapPair {
         pair: Contract,
     },

--- a/packages/shade_protocol/src/oracle.rs
+++ b/packages/shade_protocol/src/oracle.rs
@@ -58,7 +58,7 @@ pub enum HandleMsg {
     RegisterSswapPair {
         pair: Contract,
     },
-    // Unregister Secret Swap Pair (symbol/SCRT)
+    // Unregister Secret Swap Pair that corresponds to symbol/SCRT or SCRT/symbol
     UnregisterSswapPair {
         symbol: String,
     },

--- a/packages/shade_protocol/src/oracle.rs
+++ b/packages/shade_protocol/src/oracle.rs
@@ -54,11 +54,11 @@ pub enum HandleMsg {
         admin: Option<HumanAddr>,
         band: Option<Contract>,
     },
-    // Register Secret Swap Pair (should be */SCRT or SSCRT/*)
+    // Register Secret Swap Pair (should be */sSCRT or sSCRT/*)
     RegisterSswapPair {
         pair: Contract,
     },
-    // Unregister Secret Swap Pair that corresponds to symbol/SCRT or SSCRT/symbol
+    // Unregister Secret Swap Pair that corresponds to symbol/sSCRT or sSCRT/symbol
     UnregisterSswapPair {
         symbol: String,
     },

--- a/packages/shade_protocol/src/oracle.rs
+++ b/packages/shade_protocol/src/oracle.rs
@@ -58,7 +58,7 @@ pub enum HandleMsg {
     RegisterSswapPair {
         pair: Contract,
     },
-    // Unregister Secret Swap Pair that corresponds to symbol/SCRT or SCRT/symbol
+    // Unregister Secret Swap Pair that corresponds to symbol/SCRT or SSCRT/symbol
     UnregisterSswapPair {
         symbol: String,
     },

--- a/packages/shade_protocol/src/oracle.rs
+++ b/packages/shade_protocol/src/oracle.rs
@@ -58,6 +58,10 @@ pub enum HandleMsg {
     RegisterSswapPair {
         pair: Contract,
     },
+    // Unregister Secret Swap Pair (symbol/SCRT)
+    UnregisterSswapPair {
+        symbol: String,
+    },
     RegisterIndex {
         symbol: String,
         basket: Vec<IndexElement>,
@@ -76,6 +80,7 @@ impl TestHandle for HandleMsg {}
 pub enum HandleAnswer {
     UpdateConfig { status: ResponseStatus},
     RegisterSswapPair { status: ResponseStatus},
+    UnregisterSswapPair { status: ResponseStatus},
     RegisterIndex { status: ResponseStatus},
 }
 

--- a/packages/shade_protocol/src/oracle.rs
+++ b/packages/shade_protocol/src/oracle.rs
@@ -58,9 +58,9 @@ pub enum HandleMsg {
     RegisterSswapPair {
         pair: Contract,
     },
-    // Unregister Secret Swap Pair that corresponds to symbol/sSCRT or sSCRT/symbol
+    // Unregister Secret Swap Pair (opposite action to RegisterSswapPair)
     UnregisterSswapPair {
-        symbol: String,
+        pair: Contract,
     },
     RegisterIndex {
         symbol: String,


### PR DESCRIPTION
Closes https://github.com/securesecrets/shade/issues/79.

A basic implementation for unregestering Secret Swap pair by symbol (specifying `symbol` seems to be sufficient since the only supported pairs are of the form: `*/SCRT` or `SSCRT/*`).