### PR TITLE
Airdrop decay

### DIFF
--- a/contracts/airdrop/README.md
+++ b/contracts/airdrop/README.md
@@ -7,7 +7,7 @@
         * Messages
             * [UpdateConfig](#UpdateConfig)
             * [AddTasks](#AddTasks)
-            * [Decay](#Decay)
+            * [ClaimDecay](#ClaimDecay)
     * [Task_Admin](#Task_Admin)
         * Messages
             * [CompleteTask](#CompleteTask)
@@ -19,7 +19,7 @@
         * Queries
             * [GetConfig](#GetConfig)
             * [GetDates](#GetDates)
-            * [GetEligibility](#GetEligibility)
+            * [GetAccount](#GetAccount)
     
 # Introduction
 Contract responsible to handle snip20 airdrop
@@ -33,12 +33,13 @@ Contract responsible to handle snip20 airdrop
 |admin         | String        | New contract owner; SHOULD be a valid bech32 address |  yes     |
 |dump_address  | String        | Where the decay amount will be sent                  |  yes     |
 |airdrop_token | Contract      | The token that will be airdropped                    |  no      |
-| airdrop_amount | String      | Total airdrop amount to be claimed                   |  no      |
-|start_time    | u64           | When the airdrop starts in UNIX time                 |  yes     |
-|end_time      | u64           | When the airdrop ends in UNIX time                   |  yes     |
-| merkle_root  | String        | Base 64 encoded merkle root of the airdrop data tree |  no      |
-| total_accounts | String      | Total accounts in airdrop (needed for merkle proof)  |  no      |
-| max_amount   | String        | Used to limit the user permit amounts (lowers exploit possibility) |  no|
+|airdrop_amount | String      | Total airdrop amount to be claimed                   |  no      |
+|start_date    | u64           | When the airdrop starts in UNIX time                 |  yes     |
+|end_date      | u64           | When the airdrop ends in UNIX time                   |  yes     |
+|decay_start   | u64          | When the airdrop decay starts in UNIX time           | yes|
+|merkle_root  | String        | Base 64 encoded merkle root of the airdrop data tree |  no      |
+|total_accounts | String      | Total accounts in airdrop (needed for merkle proof)  |  no      |
+|max_amount   | String        | Used to limit the user permit amounts (lowers exploit possibility) |  no|
 |default_claim | String        | The default amount to be gifted regardless of tasks  |  no      |
 |task_claim    | RequiredTasks | The amounts per tasks to gift                        |  no      |
 
@@ -53,8 +54,9 @@ Updates the given values
 |--------------|------------|-------------------------------------------------------|----------|
 |admin         | string     |  New contract admin; SHOULD be a valid bech32 address |  yes     |
 | dump_address | string     | Sets the dump address if there isnt any               |  yes     |
-|start_time    | u64        | When the airdrop starts in UNIX time                  |  yes     |
-|end_time      | u64        | When the airdrop ends in UNIX time                    |  yes     |
+|start_date    | u64        | When the airdrop starts in UNIX time                  |  yes     |
+|end_date      | u64        | When the airdrop ends in UNIX time                    |  yes     |
+|decay_start   | u64        | When the airdrop decay starts in UNIX time            |  yes |
 
 #### AddTasks
 Adds more tasks to complete
@@ -72,13 +74,13 @@ Adds more tasks to complete
 }
 ```
 
-#### Decay
+#### ClaimDecay
 Drains the decayed amount of airdrop into a dump address
 
 ##### Response
 ```json
 {
-  "decay": {
+  "claim_decay": {
     "status": "success"
   }
 }
@@ -168,22 +170,29 @@ Gets the contract's config
 ```
 
 ## GetDates
-Get the contracts airdrop timeframe
+Get the contracts airdrop timeframe, can calculate the decay factor if a time is given
+##### Request
+|Name    |Type    |Description                          | optional |
+|--------|--------|-------------------------------------|----------|
+|current_date | u64 | The current time in UNIX format | yes       |
 ```json
 {
   "dates": {
     "start": "Airdrop start",
-    "end": "Airdrop end"
+    "end": "Airdrop end",
+    "decay_start": "Airdrop start of decay",
+    "decay_factor": "Decay percentage"
   }
 }
 ```
 
-## GetEligibility
-Get the contract's eligibility per user
+## GetAccount
+Get the account's information
 ##### Request
 |Name    |Type    |Description                          | optional |
 |--------|--------|-------------------------------------|----------|
-|address | String | The address to check eligibility of | no       |
+|permit  | [AddressProofPermit](#AddressProofPermit)|Address's permit | no |
+|current_date | u64 | Current time in UNIT format       | yes      |
 ```json
 {
   "eligibility": {

--- a/contracts/airdrop/src/contract.rs
+++ b/contracts/airdrop/src/contract.rs
@@ -5,7 +5,7 @@ use shade_protocol::{
         QueryMsg, Config, claim_info::RequiredTask
     }
 };
-use crate::{state::{config_w, total_claimed_w, address_in_account_w},
+use crate::{state::{config_w, total_claimed_w},
             handle::{try_update_config, try_add_tasks, try_complete_task, try_create_account,
                      try_update_account, try_disable_permit_key, try_claim, try_claim_decay},
             query };

--- a/contracts/airdrop/src/contract.rs
+++ b/contracts/airdrop/src/contract.rs
@@ -7,7 +7,7 @@ use shade_protocol::{
 };
 use crate::{state::{config_w, total_claimed_w, address_in_account_w},
             handle::{try_update_config, try_add_tasks, try_complete_task, try_create_account,
-                     try_update_account, try_disable_permit_key, try_claim, try_decay},
+                     try_update_account, try_disable_permit_key, try_claim, try_claim_decay},
             query };
 
 pub fn init<S: Storage, A: Api, Q: Querier>(
@@ -93,7 +93,7 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
     match msg {
         HandleMsg::UpdateConfig {
             admin, dump_address,
-            start_date, end_date, start_decay
+            start_date, end_date, decay_start: start_decay
         } => try_update_config(deps, env, admin, dump_address,
                                start_date, end_date, start_decay),
         HandleMsg::AddTasks { tasks
@@ -107,7 +107,7 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
         HandleMsg::DisablePermitKey { key
         } => try_disable_permit_key(deps, &env, key),
         HandleMsg::Claim { } => try_claim(deps, &env),
-        HandleMsg::Decay { } => try_decay(deps, &env),
+        HandleMsg::ClaimDecay { } => try_claim_decay(deps, &env),
     }
 }
 
@@ -118,7 +118,7 @@ pub fn query<S: Storage, A: Api, Q: Querier>(
     match msg {
         QueryMsg::GetConfig { } => to_binary(&query::config(&deps)?),
         QueryMsg::GetDates { current_date } => to_binary(&query::dates(&deps, current_date)?),
-        QueryMsg::GetAccount { address, permit, current_date } => to_binary(
-            &query::account(&deps, address, permit, current_date)?),
+        QueryMsg::GetAccount { permit, current_date } => to_binary(
+            &query::account(&deps, permit, current_date)?),
     }
 }

--- a/contracts/airdrop/src/contract.rs
+++ b/contracts/airdrop/src/contract.rs
@@ -117,8 +117,8 @@ pub fn query<S: Storage, A: Api, Q: Querier>(
 ) -> StdResult<Binary> {
     match msg {
         QueryMsg::GetConfig { } => to_binary(&query::config(&deps)?),
-        QueryMsg::GetDates { } => to_binary(&query::dates(&deps)?),
-        QueryMsg::GetAccount { address, permit } => to_binary(
-            &query::account(&deps, address, permit)?),
+        QueryMsg::GetDates { current_date } => to_binary(&query::dates(&deps, current_date)?),
+        QueryMsg::GetAccount { address, permit, current_date } => to_binary(
+            &query::account(&deps, address, permit, current_date)?),
     }
 }

--- a/contracts/airdrop/src/handle.rs
+++ b/contracts/airdrop/src/handle.rs
@@ -5,7 +5,7 @@ use crate::state::{
     total_claimed_w, total_claimed_r, account_r, address_in_account_w, account_w, validate_permit,
     revoke_permit
 };
-use shade_protocol::{airdrop::{HandleAnswer, Config, claim_info::{RequiredTask, Reward},
+use shade_protocol::{airdrop::{HandleAnswer, Config, claim_info::{RequiredTask},
                                account::{Account, AddressProofPermit}},
                      generic_response::ResponseStatus};
 use secret_toolkit::snip20::send_msg;
@@ -413,7 +413,7 @@ pub fn claim_tokens<S: Storage>(
     account: &Account,
     completed_percentage: Uint128,
     unclaimed_percentage: Uint128,
-) -> StdResult<(Uint128)> { // send_amount
+) -> StdResult<Uint128> { // send_amount
     let sender = env.message.sender.to_string();
 
     // Amount to be redeemed

--- a/contracts/airdrop/src/handle.rs
+++ b/contracts/airdrop/src/handle.rs
@@ -344,7 +344,7 @@ pub fn try_claim<S: Storage, A: Api, Q: Querier>(
     })
 }
 
-pub fn try_decay<S: Storage, A: Api, Q: Querier>(
+pub fn try_claim_decay<S: Storage, A: Api, Q: Querier>(
     deps: &mut Extern<S, A, Q>,
     env: &Env,
 ) -> StdResult<HandleResponse> {
@@ -363,7 +363,7 @@ pub fn try_decay<S: Storage, A: Api, Q: Querier>(
                 return Ok(HandleResponse {
                     messages,
                     log: vec![],
-                    data: Some( to_binary( &HandleAnswer::Decay {
+                    data: Some( to_binary( &HandleAnswer::ClaimDecay {
                         status: ResponseStatus::Success } )? )
                 })
             }

--- a/contracts/airdrop/src/handle.rs
+++ b/contracts/airdrop/src/handle.rs
@@ -150,11 +150,26 @@ pub fn try_create_account<S: Storage, A: Api, Q: Querier>(
     claim_status_w(&mut deps.storage, 0).save(sender.as_bytes(), &false)?;
 
     // Claim the airdrop after account creation
-    //TODO: replace with claim function to avoid double checking airdrop config
-    try_claim(deps, env);
+    let (completed_percentage, unclaimed_percentage) = update_tasks(&mut deps.storage,
+                                                                    &config, sender.to_string())?;
+    let mut messages = vec![];
+    // Avoid calculating if theres nothing to claim
+    if unclaimed_percentage > Uint128::zero() {
+        let redeem_amount = claim_tokens(&mut deps.storage, env, &config, &account,
+                                         completed_percentage, unclaimed_percentage)?;
+
+        total_claimed_w(&mut deps.storage).update(|claimed| {
+            Ok(claimed + redeem_amount)
+        })?;
+
+        messages.push(send_msg(env.message.sender.clone(), redeem_amount,
+                               None, None, 0,
+                               config.airdrop_snip20.code_hash,
+                               config.airdrop_snip20.address)?);
+    }
 
     Ok(HandleResponse {
-        messages: vec![],
+        messages,
         log: vec![],
         data: Some( to_binary( &HandleAnswer::CreateAccount {
             status: ResponseStatus::Success } )? )
@@ -178,39 +193,60 @@ pub fn try_update_account<S: Storage, A: Api, Q: Querier>(
     let sender = env.message.sender.clone().to_string();
     let mut account = account_r(&deps.storage).load(sender.as_bytes())?;
 
-    // Run the claim function
+    // Run the claim function if theres something to claim
     let old_claim_amount = account.total_claimable;
-    let (redeem_amount, completed_percentage) = claim_tokens(&mut deps.storage, env, &config, &account)?;
+    let (completed_percentage, unclaimed_percentage) = update_tasks(&mut deps.storage,
+                                                                    &config, sender.to_string())?;
+
+    let mut redeem_amount = Uint128::zero();
+
+    if unclaimed_percentage > Uint128::zero() {
+        redeem_amount = claim_tokens(&mut deps.storage, env, &config, &account,
+                     completed_percentage, unclaimed_percentage)?;
+    }
 
     // Setup the new addresses
     try_add_account_addresses(&mut deps.storage, &config, &env.message.sender, &mut account, addresses, partial_tree)?;
 
-    // Calculate the total new address amount
-    let added_address_total = (account.total_claimable - old_claim_amount)?;
-    let mut new_redeem = Uint128::zero();
-    account_total_claimed_w(&mut deps.storage).update(sender.as_bytes(), |claimed| {
-        if completed_percentage == Uint128(100) {
-            new_redeem += added_address_total;
-            Ok(account.total_claimable)
-        }
-        else {
-            new_redeem += completed_percentage.multiply_ratio(
-                added_address_total, Uint128(100));
-            Ok(claimed.unwrap() + new_redeem)
-        }
-    })?;
+    let mut messages = vec![];
+    if completed_percentage > Uint128::zero() {
+        // Calculate the total new address amount
+        let added_address_total = (account.total_claimable - old_claim_amount)?;
+        account_total_claimed_w(&mut deps.storage).update(sender.as_bytes(), |claimed| {
+            if let Some(claimed) = claimed {
+                let new_redeem: Uint128;
+                if completed_percentage == Uint128(100) {
+                    new_redeem = added_address_total * decay_factor(
+                        env.block.time, &config);
+                }
+                else {
+                    new_redeem = completed_percentage.multiply_ratio(
+                        added_address_total, Uint128(100)) * decay_factor(
+                        env.block.time, &config);
+                }
 
-    total_claimed_w(&mut deps.storage).update(|claimed| {
-        Ok(claimed + new_redeem)
-    })?;
+                redeem_amount += new_redeem;
+                Ok(claimed + new_redeem)
+            }
+            else {
+                return Err(StdError::generic_err("Account total claimed not set"))
+            }
+        })?;
+
+        total_claimed_w(&mut deps.storage).update(|claimed| {
+            Ok(claimed + redeem_amount)
+        })?;
+
+        messages.push(send_msg(env.message.sender.clone(), redeem_amount,
+                               None, None, 0,
+                               config.airdrop_snip20.code_hash,
+                               config.airdrop_snip20.address)?);
+    }
 
     account_w(&mut deps.storage).save(sender.as_bytes(), &account)?;
 
     Ok(HandleResponse {
-        messages: vec![send_msg(env.message.sender.clone(), redeem_amount+new_redeem,
-                                None, None, 0,
-                                config.airdrop_snip20.code_hash,
-                                config.airdrop_snip20.address)?],
+        messages,
         log: vec![],
         data: Some( to_binary( &HandleAnswer::UpdateAccount {
             status: ResponseStatus::Success } )? )
@@ -283,7 +319,19 @@ pub fn try_claim<S: Storage, A: Api, Q: Querier>(
     let account = account_r(&deps.storage).load(sender.to_string().as_bytes())?;
 
     // Calculate airdrop
-    let (redeem_amount, _) = claim_tokens(&mut deps.storage, env, &config, &account)?;
+    let (completed_percentage, unclaimed_percentage) = update_tasks(&mut deps.storage,
+                                                                    &config, sender.to_string())?;
+
+    if unclaimed_percentage == Uint128::zero() {
+        return Err(StdError::generic_err("No claimable amount available"))
+    }
+
+    let redeem_amount = claim_tokens(&mut deps.storage, env, &config, &account,
+                                          completed_percentage, unclaimed_percentage)?;
+
+    total_claimed_w(&mut deps.storage).update(|claimed| {
+        Ok(claimed + redeem_amount)
+    })?;
 
     Ok(HandleResponse {
         messages: vec![send_msg(sender, redeem_amount,
@@ -325,14 +373,12 @@ pub fn try_decay<S: Storage, A: Api, Q: Querier>(
     Err(StdError::unauthorized())
 }
 
-pub fn claim_tokens<S: Storage>(
+/// Gets task information and sets them
+pub fn update_tasks<S: Storage>(
     storage: &mut S,
-    env: &Env,
     config: &Config,
-    account: &Account,
-) -> StdResult<(Uint128, Uint128)> { // (send_amount, completed_percentage)
-    let sender = env.message.sender.to_string();
-
+    sender: String,
+) -> StdResult<(Uint128, Uint128)> {
     // Calculate eligible tasks
     let mut completed_percentage = Uint128::zero();
     let mut unclaimed_percentage = Uint128::zero();
@@ -357,40 +403,45 @@ pub fn claim_tokens<S: Storage>(
         }
     }
 
-    if unclaimed_percentage == Uint128::zero() {
-        return Err(StdError::generic_err("No claimable amount available"))
-    }
+    Ok((completed_percentage, unclaimed_percentage))
+}
+
+pub fn claim_tokens<S: Storage>(
+    storage: &mut S,
+    env: &Env,
+    config: &Config,
+    account: &Account,
+    completed_percentage: Uint128,
+    unclaimed_percentage: Uint128,
+) -> StdResult<(Uint128)> { // send_amount
+    let sender = env.message.sender.to_string();
 
     // Amount to be redeemed
     let mut redeem_amount = Uint128::zero();
 
     // Update total claimed and calculate claimable
     account_total_claimed_w(storage).update(sender.as_bytes(), |claimed| {
-        // This solves possible uToken inaccuracies
-        if completed_percentage == Uint128(100) {
-            redeem_amount = (account.total_claimable - claimed.unwrap())?;
-            Ok(account.total_claimable)
+        if let Some(claimed) = claimed {
+            // This solves possible uToken inaccuracies
+            if completed_percentage == Uint128(100) {
+                redeem_amount = (account.total_claimable - claimed)?;
+            }
+            else {
+                redeem_amount = unclaimed_percentage.multiply_ratio(
+                    account.total_claimable, Uint128(100));
+            }
+
+            // Update redeem amount with the decay multiplier
+            redeem_amount = redeem_amount * decay_factor(env.block.time, &config);
+
+            Ok(claimed + redeem_amount)
         }
         else {
-            redeem_amount = unclaimed_percentage.multiply_ratio(account.total_claimable, Uint128(100));
-            Ok(claimed.unwrap() + redeem_amount)
+            return Err(StdError::generic_err("Account total claimed not set"))
         }
     })?;
 
-    // Calculate redeem amount after applying decay
-    if let Some(decay_start) = config.decay_start {
-        if env.block.time >= decay_start {
-            redeem_amount = redeem_amount * calculate_decay_factor(decay_start,
-                                                                   env.block.time,
-                                                                   config.end_date.unwrap());
-        }
-    }
-
-    total_claimed_w(storage).update(|claimed| {
-        Ok(claimed + redeem_amount)
-    })?;
-
-    Ok((redeem_amount, completed_percentage))
+    Ok(redeem_amount)
 }
 
 /// Validates all of the information and updates relevant states
@@ -491,7 +542,18 @@ pub fn available( config: &Config, env: &Env ) -> StdResult<()> {
     Ok(())
 }
 
-pub fn calculate_decay_factor(min: u64, x: u64, max: u64) -> Decimal {
-    // Get the inverse normalized value [0,1] of x between [min, max]
+/// Get the multiplier for decay, will return 1 when decay isnt in effect.
+pub fn decay_factor(current_time: u64, config: &Config) -> Decimal {
+    // Calculate redeem amount after applying decay
+    if let Some(decay_start) = config.decay_start {
+        if current_time >= decay_start {
+            return inverse_normalizer(decay_start, current_time, config.end_date.unwrap())
+        }
+    }
+    Decimal::one()
+}
+
+/// Get the inverse normalized value [0,1] of x between [min, max]
+pub fn inverse_normalizer(min: u64, x: u64, max: u64) -> Decimal {
     Decimal::from_ratio(max - x, max - min)
 }

--- a/contracts/airdrop/src/lib.rs
+++ b/contracts/airdrop/src/lib.rs
@@ -3,6 +3,9 @@ pub mod handle;
 pub mod query;
 pub mod state;
 
+#[cfg(test)]
+mod test;
+
 #[cfg(target_arch = "wasm32")]
 mod wasm {
     use super::contract;

--- a/contracts/airdrop/src/query.rs
+++ b/contracts/airdrop/src/query.rs
@@ -1,7 +1,7 @@
 use cosmwasm_std::{Api, Extern, Querier, StdResult, Storage, HumanAddr, Uint128, StdError};
 use shade_protocol::airdrop::{QueryAnswer, account::AddressProofPermit, claim_info::RequiredTask};
-use crate::state::{config_r, claim_status_r,
-                   total_claimed_r, validate_permit, account_r};
+use crate::handle::decay_factor;
+use crate::state::{config_r, claim_status_r, total_claimed_r, validate_permit, account_r, account_total_claimed_r};
 
 pub fn config<S: Storage, A: Api, Q: Querier>
 (deps: &Extern<S, A, Q>) -> StdResult<QueryAnswer> {
@@ -12,14 +12,22 @@ pub fn config<S: Storage, A: Api, Q: Querier>
 }
 
 pub fn dates<S: Storage, A: Api, Q: Querier>
-(deps: &Extern<S, A, Q>) -> StdResult<QueryAnswer> {
+(deps: &Extern<S, A, Q>, current_date: Option<u64>) -> StdResult<QueryAnswer> {
     let config = config_r(&deps.storage).load()?;
-    Ok(QueryAnswer::Dates { start: config.start_date, end: config.end_date
+    Ok(QueryAnswer::Dates {
+        start: config.start_date,
+        end: config.end_date,
+        decay_start: config.decay_start,
+        decay_factor: match current_date {
+            None => None,
+            Some(date) => Some(Uint128(100) * decay_factor(date, &config))
+        }
     })
 }
 
 pub fn account<S: Storage, A: Api, Q: Querier>(
-    deps: &Extern<S, A, Q>, address: HumanAddr, permit: AddressProofPermit
+    deps: &Extern<S, A, Q>, address: HumanAddr,
+    permit: AddressProofPermit, current_date: Option<u64>
 ) -> StdResult<QueryAnswer> {
 
     let config = config_r(&deps.storage).load()?;
@@ -57,15 +65,7 @@ pub fn account<S: Storage, A: Api, Q: Querier>(
         }
     }
 
-    let claimed: Uint128;
-    let unclaimed: Uint128;
-
-    if completed_percentage == Uint128(100) {
-        claimed = account.total_claimable;
-    }
-    else {
-        claimed = completed_percentage.multiply_ratio(account.total_claimable, Uint128(100));
-    }
+    let mut unclaimed: Uint128;
 
     if unclaimed_percentage == Uint128(100) {
         unclaimed = account.total_claimable;
@@ -74,9 +74,13 @@ pub fn account<S: Storage, A: Api, Q: Querier>(
         unclaimed = unclaimed_percentage.multiply_ratio(account.total_claimable, Uint128(100));
     }
 
+    if let Some(time) = current_date {
+        unclaimed = unclaimed * decay_factor(time, &config);
+    }
+
     Ok(QueryAnswer::Account {
         total: account.total_claimable,
-        claimed,
+        claimed: account_total_claimed_r(&deps.storage).load(address.to_string().as_bytes())?,
         unclaimed,
         finished_tasks
     })

--- a/contracts/airdrop/src/query.rs
+++ b/contracts/airdrop/src/query.rs
@@ -26,19 +26,14 @@ pub fn dates<S: Storage, A: Api, Q: Querier>
 }
 
 pub fn account<S: Storage, A: Api, Q: Querier>(
-    deps: &Extern<S, A, Q>, address: HumanAddr,
-    permit: AddressProofPermit, current_date: Option<u64>
+    deps: &Extern<S, A, Q>, permit: AddressProofPermit, current_date: Option<u64>
 ) -> StdResult<QueryAnswer> {
 
     let config = config_r(&deps.storage).load()?;
 
     let account_address = validate_permit(&deps.storage, &permit, config.contract)?;
 
-    if account_address != address {
-        return Err(StdError::unauthorized())
-    }
-
-    let account = account_r(&deps.storage).load(address.to_string().as_bytes())?;
+    let account = account_r(&deps.storage).load(account_address.to_string().as_bytes())?;
 
     // Calculate eligible tasks
     let config = config_r(&deps.storage).load()?;
@@ -48,7 +43,7 @@ pub fn account<S: Storage, A: Api, Q: Querier>(
     for (index, task) in config.task_claim.iter().enumerate() {
         // Check if task has been completed
         let state = claim_status_r(&deps.storage, index).may_load(
-            address.to_string().as_bytes())?;
+            account_address.to_string().as_bytes())?;
 
         match state {
             // Ignore if none
@@ -80,7 +75,7 @@ pub fn account<S: Storage, A: Api, Q: Querier>(
 
     Ok(QueryAnswer::Account {
         total: account.total_claimable,
-        claimed: account_total_claimed_r(&deps.storage).load(address.to_string().as_bytes())?,
+        claimed: account_total_claimed_r(&deps.storage).load(account_address.to_string().as_bytes())?,
         unclaimed,
         finished_tasks
     })

--- a/contracts/airdrop/src/query.rs
+++ b/contracts/airdrop/src/query.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Api, Extern, Querier, StdResult, Storage, HumanAddr, Uint128, StdError};
+use cosmwasm_std::{Api, Extern, Querier, StdResult, Storage, Uint128};
 use shade_protocol::airdrop::{QueryAnswer, account::AddressProofPermit, claim_info::RequiredTask};
 use crate::handle::decay_factor;
 use crate::state::{config_r, claim_status_r, total_claimed_r, validate_permit, account_r, account_total_claimed_r};

--- a/contracts/airdrop/src/state.rs
+++ b/contracts/airdrop/src/state.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{Storage, Uint128, StdResult, HumanAddr, StdError};
 use cosmwasm_storage::{singleton, singleton_read, ReadonlySingleton, Singleton, bucket, Bucket, bucket_read, ReadonlyBucket};
-use shade_protocol::airdrop::{Config, claim_info::Reward, account::Account};
+use shade_protocol::airdrop::{Config, account::Account};
 use shade_protocol::airdrop::account::AddressProofPermit;
 
 pub static CONFIG_KEY: &[u8] = b"config";

--- a/contracts/airdrop/src/test.rs
+++ b/contracts/airdrop/src/test.rs
@@ -1,0 +1,18 @@
+#[cfg(test)]
+pub mod tests {
+    use cosmwasm_std::testing::{mock_dependencies, mock_env};
+    use cosmwasm_std::Uint128;
+    use shade_protocol::airdrop::claim_info::RequiredTask;
+    use shade_protocol::airdrop::InitMsg;
+    use shade_protocol::asset::Contract;
+    use crate::contract::init;
+    use crate::handle::calculate_decay_factor;
+
+
+    #[test]
+    fn decay_factor() {
+        assert_eq!(Uint128(50), Uint128(100) * calculate_decay_factor(100, 200, 300));
+
+        assert_eq!(Uint128(25), Uint128(100) * calculate_decay_factor(0, 75, 100));
+    }
+}

--- a/contracts/airdrop/src/test.rs
+++ b/contracts/airdrop/src/test.rs
@@ -6,13 +6,12 @@ pub mod tests {
     use shade_protocol::airdrop::InitMsg;
     use shade_protocol::asset::Contract;
     use crate::contract::init;
-    use crate::handle::calculate_decay_factor;
-
+    use crate::handle::inverse_normalizer;
 
     #[test]
     fn decay_factor() {
-        assert_eq!(Uint128(50), Uint128(100) * calculate_decay_factor(100, 200, 300));
+        assert_eq!(Uint128(50), Uint128(100) * inverse_normalizer(100, 200, 300));
 
-        assert_eq!(Uint128(25), Uint128(100) * calculate_decay_factor(0, 75, 100));
+        assert_eq!(Uint128(25), Uint128(100) * inverse_normalizer(0, 75, 100));
     }
 }

--- a/packages/network_integration/tests/testnet_integration.rs
+++ b/packages/network_integration/tests/testnet_integration.rs
@@ -141,6 +141,8 @@ fn run_airdrop() -> Result<()> {
 
     let now = chrono::offset::Utc::now().timestamp() as u64;
     let duration = 180;
+    let decay_date = now + duration;
+    let end_date = now + duration + 80;
 
     let airdrop_init_msg = airdrop::InitMsg {
         admin: None,
@@ -150,8 +152,10 @@ fn run_airdrop() -> Result<()> {
             code_hash: snip.code_hash.clone()
         },
         airdrop_amount: total_airdrop+decay_amount,
-        start_time: None,
-        end_time: Some(now + duration),
+        start_date: None,
+        // Add one more minute for testing decay
+        end_date: Some(end_date),
+        decay_start: Some(decay_date),
         merkle_root: Binary(merlke_tree.root().unwrap().to_vec()),
         total_accounts: leaves.len() as u32,
         max_amount: a_airdrop,
@@ -203,7 +207,7 @@ fn run_airdrop() -> Result<()> {
 
     let a_permit = create_signed_permit(a_address_proof, ACCOUNT_KEY);
 
-    /// Create an account
+    /// Create an account which will also claim whatever amount is available
     print_warning("Creating an account");
     {
         let tx_info = test_contract_handle(&airdrop::HandleMsg::CreateAccount {
@@ -217,34 +221,8 @@ fn run_airdrop() -> Result<()> {
     {
         let msg = airdrop::QueryMsg::GetAccount {
             address: HumanAddr(account_a.clone()),
-            permit: a_permit.clone()
-        };
-
-        let query: airdrop::QueryAnswer = query_contract(&airdrop, msg)?;
-
-        if let airdrop::QueryAnswer::Account { total, claimed,
-            unclaimed, finished_tasks } = query {
-            assert_eq!(total, a_airdrop + b_airdrop);
-            assert_eq!(claimed, Uint128::zero());
-            assert_eq!(unclaimed, ab_half_airdrop);
-            assert_eq!(finished_tasks.len(), 1);
-        }
-    }
-
-    print_warning("Claiming half of the airdrop");
-    /// Claim airdrop
-    test_contract_handle(&airdrop::HandleMsg::Claim {},
-                         &airdrop, ACCOUNT_KEY, Some(GAS),
-                         Some("test"), None)?;
-
-    /// Assert that we claimed
-    assert_eq!(ab_half_airdrop, get_balance(&snip, account_a.clone()));
-
-    /// Query that half of the airdrop is claimed
-    {
-        let msg = airdrop::QueryMsg::GetAccount {
-            address: HumanAddr(account_a.clone()),
-            permit: a_permit.clone()
+            permit: a_permit.clone(),
+            current_date: None
         };
 
         let query: airdrop::QueryAnswer = query_contract(&airdrop, msg)?;
@@ -258,6 +236,9 @@ fn run_airdrop() -> Result<()> {
         }
     }
 
+    /// Assert that we claimed
+    assert_eq!(ab_half_airdrop, get_balance(&snip, account_a.clone()));
+
     print_warning("Enabling the other half of the airdrop");
 
     test_contract_handle(&airdrop::HandleMsg::CompleteTask {
@@ -268,7 +249,8 @@ fn run_airdrop() -> Result<()> {
     {
         let msg = airdrop::QueryMsg::GetAccount {
             address: HumanAddr(account_a.clone()),
-            permit: a_permit.clone()
+            permit: a_permit.clone(),
+            current_date: None
         };
 
         let query: airdrop::QueryAnswer = query_contract(&airdrop, msg)?;
@@ -306,7 +288,8 @@ fn run_airdrop() -> Result<()> {
     {
         let msg = airdrop::QueryMsg::GetAccount {
             address: HumanAddr(account_a.clone()),
-            permit: a_permit.clone()
+            permit: a_permit.clone(),
+            current_date: None
         };
 
         let query: airdrop::QueryAnswer = query_contract(&airdrop, msg)?;
@@ -328,7 +311,8 @@ fn run_airdrop() -> Result<()> {
     {
         let msg = airdrop::QueryMsg::GetAccount {
             address: HumanAddr(account_a.clone()),
-            permit: a_permit.clone()
+            permit: a_permit.clone(),
+            current_date: None
         };
 
         let query: Result<airdrop::QueryAnswer> = query_contract(&airdrop, msg);
@@ -349,7 +333,8 @@ fn run_airdrop() -> Result<()> {
     {
         let msg = airdrop::QueryMsg::GetAccount {
             address: HumanAddr(account_a.clone()),
-            permit: new_a_permit.clone()
+            permit: new_a_permit.clone(),
+            current_date: None
         };
 
         let query: airdrop::QueryAnswer = query_contract(&airdrop, msg)?;
@@ -363,9 +348,43 @@ fn run_airdrop() -> Result<()> {
         }
     }
 
+    print_warning("Claiming partially decayed tokens");
+    {
+        let current = chrono::offset::Utc::now().timestamp() as u64;
+        // Wait until times is between decay start and end of airdrop
+        thread::sleep(time::Duration::from_secs(decay_date - current + 30));
+    }
+
+    {
+        let d_address_proof = AddressProofMsg {
+            address: HumanAddr(account_d.clone()),
+            amount: decay_amount,
+            contract: HumanAddr(airdrop.address.clone()),
+            index: 3,
+            key: "key".to_string(),
+        };
+
+        let d_permit = create_signed_permit(d_address_proof, "d");
+        let d_proof = proof_from_tree(&vec![3], &merlke_tree.layers());
+
+        test_contract_handle(&airdrop::HandleMsg::UpdateAccount {
+            addresses: vec![d_permit],
+            partial_tree: d_proof,
+        }, &airdrop, ACCOUNT_KEY,
+                             Some("1000000"), Some("test"), None)?;
+
+        let balance = get_balance(&snip, account_a.clone());
+
+        assert!(balance > total_airdrop && balance < total_airdrop + decay_amount);
+    }
+
     /// Try to claim expired tokens
     print_warning("Claiming expired tokens");
-    thread::sleep(time::Duration::from_secs(duration));
+    {
+        let current = chrono::offset::Utc::now().timestamp() as u64;
+        // Wait until times is between decay start and end of airdrop
+        thread::sleep(time::Duration::from_secs(end_date - current + 4));
+    }
 
     test_contract_handle(&airdrop::HandleMsg::Decay {},
                          &airdrop, ACCOUNT_KEY, Some(GAS),
@@ -592,6 +611,7 @@ fn run_testnet() -> Result<()> {
 
     print_warning("Voting on proposal");
     {
+        let proposal_time = chrono::offset::Utc::now().timestamp() as u64;
         let proposal = get_latest_proposal(&governance)?;
 
         // Vote on proposal
@@ -635,7 +655,9 @@ fn run_testnet() -> Result<()> {
         }
 
         // Wait for the time limit and try to trigger it
-        thread::sleep(time::Duration::from_secs(180));
+        let now = chrono::offset::Utc::now().timestamp() as u64;
+        thread::sleep(time::Duration::from_secs(proposal_time + 184 - now));
+
         trigger_latest_proposal(&governance)?;
 
         // Query its status and expect it to break
@@ -662,6 +684,7 @@ fn run_testnet() -> Result<()> {
 
 
     {
+        let proposal_time = chrono::offset::Utc::now().timestamp() as u64;
         let proposal = get_latest_proposal(&governance)?;
 
         print_warning("Funding proposal");
@@ -685,7 +708,8 @@ fn run_testnet() -> Result<()> {
                              Some("test"), None)?;
 
         // Wait for the time limit and try to trigger it
-        thread::sleep(time::Duration::from_secs(180));
+        let now = chrono::offset::Utc::now().timestamp() as u64;
+        thread::sleep(time::Duration::from_secs(proposal_time + 184 - now));
         trigger_latest_proposal(&governance)?;
 
         // Query its status and expect it to finish
@@ -738,6 +762,7 @@ fn run_testnet() -> Result<()> {
     {
         print_warning("Trying to fund");
         let proposal = get_latest_proposal(&governance)?;
+        let proposal_time = chrono::offset::Utc::now().timestamp() as u64;
 
         let lost_amount = Uint128(500000);
         let balance_before = get_balance(&shade, account.clone());
@@ -756,7 +781,8 @@ fn run_testnet() -> Result<()> {
         assert_ne!(balance_before, balance_after);
 
         // Wait funding period
-        thread::sleep(time::Duration::from_secs(180));
+        let now = chrono::offset::Utc::now().timestamp() as u64;
+        thread::sleep(time::Duration::from_secs(proposal_time + 184 - now));
 
         // Trigger funding
         test_contract_handle(&snip20::HandleMsg::Send {

--- a/packages/network_integration/tests/testnet_integration.rs
+++ b/packages/network_integration/tests/testnet_integration.rs
@@ -220,7 +220,6 @@ fn run_airdrop() -> Result<()> {
     print_warning("Getting initial account information");
     {
         let msg = airdrop::QueryMsg::GetAccount {
-            address: HumanAddr(account_a.clone()),
             permit: a_permit.clone(),
             current_date: None
         };
@@ -248,7 +247,6 @@ fn run_airdrop() -> Result<()> {
 
     {
         let msg = airdrop::QueryMsg::GetAccount {
-            address: HumanAddr(account_a.clone()),
             permit: a_permit.clone(),
             current_date: None
         };
@@ -287,7 +285,6 @@ fn run_airdrop() -> Result<()> {
     /// Query that all of the airdrop is claimed
     {
         let msg = airdrop::QueryMsg::GetAccount {
-            address: HumanAddr(account_a.clone()),
             permit: a_permit.clone(),
             current_date: None
         };
@@ -310,7 +307,6 @@ fn run_airdrop() -> Result<()> {
 
     {
         let msg = airdrop::QueryMsg::GetAccount {
-            address: HumanAddr(account_a.clone()),
             permit: a_permit.clone(),
             current_date: None
         };
@@ -332,7 +328,6 @@ fn run_airdrop() -> Result<()> {
 
     {
         let msg = airdrop::QueryMsg::GetAccount {
-            address: HumanAddr(account_a.clone()),
             permit: new_a_permit.clone(),
             current_date: None
         };
@@ -386,7 +381,7 @@ fn run_airdrop() -> Result<()> {
         thread::sleep(time::Duration::from_secs(end_date - current + 4));
     }
 
-    test_contract_handle(&airdrop::HandleMsg::Decay {},
+    test_contract_handle(&airdrop::HandleMsg::ClaimDecay {},
                          &airdrop, ACCOUNT_KEY, Some(GAS),
                          Some("test"), None)?;
 

--- a/packages/shade_protocol/src/airdrop/mod.rs
+++ b/packages/shade_protocol/src/airdrop/mod.rs
@@ -22,7 +22,10 @@ pub struct Config {
     pub task_claim: Vec<RequiredTask>,
     // Checks if airdrop has started / ended
     pub start_date: u64,
+    // Airdrop stops at end date if there is one
     pub end_date: Option<u64>,
+    // Starts to decay at this date
+    pub decay_start: Option<u64>,
     // This is necessary to validate the airdrop information
     // tree root
     pub merkle_root: Binary,
@@ -41,9 +44,11 @@ pub struct InitMsg {
     // Airdrop amount
     pub airdrop_amount: Uint128,
     // The airdrop time limit
-    pub start_time: Option<u64>,
+    pub start_date: Option<u64>,
     // Can be set to never end
-    pub end_time: Option<u64>,
+    pub end_date: Option<u64>,
+    // Starts to decay at this date
+    pub decay_start: Option<u64>,
     // Base64 encoded version of the tree root
     pub merkle_root: Binary,
     // Root height
@@ -68,6 +73,7 @@ pub enum HandleMsg {
         dump_address: Option<HumanAddr>,
         start_date: Option<u64>,
         end_date: Option<u64>,
+        start_decay: Option<u64>,
     },
     AddTasks {
         tasks: Vec<RequiredTask>

--- a/packages/shade_protocol/src/airdrop/mod.rs
+++ b/packages/shade_protocol/src/airdrop/mod.rs
@@ -116,8 +116,8 @@ pub enum HandleAnswer {
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
     GetConfig { },
-    GetDates { },
-    GetAccount { address: HumanAddr, permit: AddressProofPermit },
+    GetDates { current_date: Option<u64> },
+    GetAccount { address: HumanAddr, permit: AddressProofPermit, current_date: Option<u64> },
 }
 
 impl Query for QueryMsg {
@@ -128,7 +128,7 @@ impl Query for QueryMsg {
 #[serde(rename_all = "snake_case")]
 pub enum QueryAnswer {
     Config { config: Config, total_claimed: Uint128 },
-    Dates { start: u64, end: Option<u64> },
+    Dates { start: u64, end: Option<u64>, decay_start: Option<u64>, decay_factor: Option<Uint128> },
     Account {
         // Total eligible
         total: Uint128,

--- a/packages/shade_protocol/src/airdrop/mod.rs
+++ b/packages/shade_protocol/src/airdrop/mod.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use secret_toolkit::utils::{InitCallback, HandleCallback, Query};
 use cosmwasm_std::{Binary, HumanAddr, Uint128};
 use crate::{asset::Contract, generic_response::ResponseStatus,
-            airdrop::{claim_info::{RequiredTask, Reward}, account::AddressProofPermit}};
+            airdrop::{claim_info::{RequiredTask}, account::AddressProofPermit}};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Config {

--- a/packages/shade_protocol/src/airdrop/mod.rs
+++ b/packages/shade_protocol/src/airdrop/mod.rs
@@ -73,7 +73,7 @@ pub enum HandleMsg {
         dump_address: Option<HumanAddr>,
         start_date: Option<u64>,
         end_date: Option<u64>,
-        start_decay: Option<u64>,
+        decay_start: Option<u64>,
     },
     AddTasks {
         tasks: Vec<RequiredTask>
@@ -92,7 +92,7 @@ pub enum HandleMsg {
     },
     DisablePermitKey { key: String },
     Claim {},
-    Decay {},
+    ClaimDecay {},
 }
 
 impl HandleCallback for HandleMsg {
@@ -109,7 +109,7 @@ pub enum HandleAnswer {
     UpdateAccount { status: ResponseStatus },
     DisablePermitKey { status: ResponseStatus },
     Claim { status: ResponseStatus },
-    Decay { status: ResponseStatus },
+    ClaimDecay { status: ResponseStatus },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -117,7 +117,7 @@ pub enum HandleAnswer {
 pub enum QueryMsg {
     GetConfig { },
     GetDates { current_date: Option<u64> },
-    GetAccount { address: HumanAddr, permit: AddressProofPermit, current_date: Option<u64> },
+    GetAccount { permit: AddressProofPermit, current_date: Option<u64> },
 }
 
 impl Query for QueryMsg {
@@ -128,7 +128,8 @@ impl Query for QueryMsg {
 #[serde(rename_all = "snake_case")]
 pub enum QueryAnswer {
     Config { config: Config, total_claimed: Uint128 },
-    Dates { start: u64, end: Option<u64>, decay_start: Option<u64>, decay_factor: Option<Uint128> },
+    Dates { start: u64, end: Option<u64>,
+        decay_start: Option<u64>, decay_factor: Option<Uint128> },
     Account {
         // Total eligible
         total: Uint128,


### PR DESCRIPTION
Added a time based decay where decayed amount will be the amount to claim multiplied by the inverse of a normalized function where ```decay_start``` is 0 and ```end_date``` is 1. This decay has been tested and added to all of the claim related functions.

Queries have also been expanded to provide decay information and an overview of the current decay multiplier.

When creating an account, the handle function will now automatically claim whatever amount you have available.

Solved an issue where integration test delays were not smart (delays are used to check for time based events like governance proposals and airdrop decay, start and end dates). They will now wait the required amount.

Closes #146