### PR TITLE
Airdrop permit fixes

### DIFF
--- a/contracts/airdrop/README.md
+++ b/contracts/airdrop/README.md
@@ -219,7 +219,7 @@ NOTE: The parameters must be in order
 | signature  | PermitSignature | Signature of the permit                            | no       |
 
 ## AccountProofMsg
-THe information inside permits that validate account ownership
+The information inside permits that validate account ownership
 
 NOTE: The parameters must be in order
 ### Structure

--- a/contracts/airdrop/README.md
+++ b/contracts/airdrop/README.md
@@ -191,7 +191,7 @@ Get the account's information
 ##### Request
 |Name    |Type    |Description                          | optional |
 |--------|--------|-------------------------------------|----------|
-|permit  | [AddressProofPermit](#AddressProofPermit)|Address's permit | no |
+|permit  | [AccountProofPermit](#AccountProofMsg)|Address's permit | no |
 |current_date | u64 | Current time in UNIT format       | yes      |
 ```json
 {
@@ -217,6 +217,17 @@ NOTE: The parameters must be in order
 | params     | AddressProofMsg | Information relevant to the airdrop information    | no       |
 | chain_id   | String          | Chain ID of the network this proof will be used in | no       |
 | signature  | PermitSignature | Signature of the permit                            | no       |
+
+## AccountProofMsg
+THe information inside permits that validate account ownership
+
+NOTE: The parameters must be in order
+### Structure
+| Name     | Type    | Description                                             | optional |
+|----------|---------|---------------------------------------------------------|----------|
+| contract | String  | Airdrop contract                                        | no       |
+| key      | String  | Some permit key                                         | no       |
+
 
 ## AddressProofMsg
 The information inside permits that validate the airdrop eligibility and validate the account holder's key.

--- a/contracts/airdrop/src/handle.rs
+++ b/contracts/airdrop/src/handle.rs
@@ -2,7 +2,7 @@ use cosmwasm_std::{to_binary, Api, Env, Extern, HandleResponse, Querier, StdErro
 use rs_merkle::{Hasher, MerkleProof, algorithms::Sha256};
 use crate::state::{
     config_r, config_w, claim_status_w, claim_status_r, account_total_claimed_w,
-    total_claimed_w, total_claimed_r, account_r, address_in_account_w, account_w, validate_permit,
+    total_claimed_w, total_claimed_r, account_r, address_in_account_w, account_w, validate_address_permit,
     revoke_permit
 };
 use shade_protocol::{airdrop::{HandleAnswer, Config, claim_info::{RequiredTask},
@@ -462,7 +462,7 @@ pub fn try_add_account_addresses<S: Storage>(
         // Avoid verifying sender
         if &permit.params.address != sender {
             // Check permit legitimacy
-            address = validate_permit(storage, permit, config.contract.clone())?;
+            address = validate_address_permit(storage, permit, config.contract.clone())?;
             if address != permit.params.address {
                 return Err(StdError::generic_err("Signer address is not the same as the permit address"))
             }

--- a/contracts/airdrop/src/query.rs
+++ b/contracts/airdrop/src/query.rs
@@ -1,7 +1,7 @@
 use cosmwasm_std::{Api, Extern, Querier, StdResult, Storage, Uint128};
-use shade_protocol::airdrop::{QueryAnswer, account::AddressProofPermit, claim_info::RequiredTask};
+use shade_protocol::airdrop::{QueryAnswer, account::AccountPermit, claim_info::RequiredTask};
 use crate::handle::decay_factor;
-use crate::state::{config_r, claim_status_r, total_claimed_r, validate_permit, account_r, account_total_claimed_r};
+use crate::state::{config_r, claim_status_r, total_claimed_r, validate_address_permit, account_r, account_total_claimed_r, validate_account_permit};
 
 pub fn config<S: Storage, A: Api, Q: Querier>
 (deps: &Extern<S, A, Q>) -> StdResult<QueryAnswer> {
@@ -26,12 +26,12 @@ pub fn dates<S: Storage, A: Api, Q: Querier>
 }
 
 pub fn account<S: Storage, A: Api, Q: Querier>(
-    deps: &Extern<S, A, Q>, permit: AddressProofPermit, current_date: Option<u64>
+    deps: &Extern<S, A, Q>, permit: AccountPermit, current_date: Option<u64>
 ) -> StdResult<QueryAnswer> {
 
     let config = config_r(&deps.storage).load()?;
 
-    let account_address = validate_permit(&deps.storage, &permit, config.contract)?;
+    let account_address = validate_account_permit(&deps, &permit, config.contract)?;
 
     let account = account_r(&deps.storage).load(account_address.to_string().as_bytes())?;
 

--- a/contracts/airdrop/src/state.rs
+++ b/contracts/airdrop/src/state.rs
@@ -1,7 +1,7 @@
-use cosmwasm_std::{Storage, Uint128, StdResult, HumanAddr, StdError};
-use cosmwasm_storage::{singleton, singleton_read, ReadonlySingleton, Singleton, bucket, Bucket, bucket_read, ReadonlyBucket};
-use shade_protocol::airdrop::{Config, account::Account};
-use shade_protocol::airdrop::account::AddressProofPermit;
+use cosmwasm_std::{Storage, Uint128, StdResult, HumanAddr, StdError, Api, Querier, Extern};
+use cosmwasm_storage::{singleton, singleton_read, ReadonlySingleton, Singleton,
+                       bucket, Bucket, bucket_read, ReadonlyBucket};
+use shade_protocol::airdrop::{Config, account::{Account, AccountPermit, AddressProofPermit}};
 
 pub static CONFIG_KEY: &[u8] = b"config";
 pub static CLAIM_STATUS_KEY: &[u8] = b"claim_status_";
@@ -92,7 +92,9 @@ pub fn is_permit_revoked<S: Storage>(storage: &S, account: String, permit_key: S
     }
 }
 
-pub fn validate_permit<S: Storage>(storage: &S, permit: &AddressProofPermit, contract: HumanAddr) -> StdResult<HumanAddr> {
+pub fn validate_address_permit<S: Storage>(
+    storage: &S, permit: &AddressProofPermit, contract: HumanAddr
+) -> StdResult<HumanAddr> {
     // Check that contract matches
     if permit.params.contract != contract {
         return Err(StdError::unauthorized())
@@ -106,4 +108,24 @@ pub fn validate_permit<S: Storage>(storage: &S, permit: &AddressProofPermit, con
 
     // Authenticate permit
     permit.authenticate()
+}
+
+pub fn validate_account_permit<S: Storage, A: Api, Q: Querier>(
+    deps: &Extern<S, A, Q>, permit: &AccountPermit, contract: HumanAddr
+) -> StdResult<HumanAddr> {
+    // Check that contract matches
+    if permit.params.contract != contract {
+        return Err(StdError::unauthorized())
+    }
+
+    // Authenticate permit
+    let address = permit.authenticate(&deps.api)?;
+
+    // Check that permit is not revoked
+    if is_permit_revoked(&deps.storage, address.to_string(),
+                         permit.params.key.clone())? {
+        return Err(StdError::generic_err("permit key revoked"))
+    }
+
+    Ok(address)
 }

--- a/packages/shade_protocol/src/airdrop/mod.rs
+++ b/packages/shade_protocol/src/airdrop/mod.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use secret_toolkit::utils::{InitCallback, HandleCallback, Query};
 use cosmwasm_std::{Binary, HumanAddr, Uint128};
 use crate::{asset::Contract, generic_response::ResponseStatus,
-            airdrop::{claim_info::{RequiredTask}, account::AddressProofPermit}};
+            airdrop::{claim_info::{RequiredTask}, account::{AccountPermit, AddressProofPermit}}};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Config {
@@ -117,7 +117,7 @@ pub enum HandleAnswer {
 pub enum QueryMsg {
     GetConfig { },
     GetDates { current_date: Option<u64> },
-    GetAccount { permit: AddressProofPermit, current_date: Option<u64> },
+    GetAccount { permit: AccountPermit, current_date: Option<u64> },
 }
 
 impl Query for QueryMsg {

--- a/packages/shade_protocol/src/signature/mod.rs
+++ b/packages/shade_protocol/src/signature/mod.rs
@@ -35,7 +35,6 @@ impl<T: Clone + Serialize> Permit<T> {
     /// Returns the permit signer
     pub fn validate(&self) -> StdResult<PubKeyValue> {
         let pubkey = &self.signature.pub_key.value;
-        //let account = pubkey_to_account(pubkey);
 
         // Validate signature
         let signed_bytes = to_binary(&self.create_signed_tx())?;


### PR DESCRIPTION
Expanded ```PubKey``` traits to allow for ```HumanAddress``` and ```CanonicalAddress``` creation.

```Account``` now has its own permit, its shorter and removes the unnecessary things needed for address proof