### PR TITLE
Airdrop | query protection

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "contracts/snip20"]
 	path = contracts/snip20
-	url = git@github.com:enigmampc/snip20-reference-impl.git
+	url = https://github.com/scrtlabs/snip20-reference-impl.git
   branch = master

--- a/contracts/airdrop/src/contract.rs
+++ b/contracts/airdrop/src/contract.rs
@@ -9,6 +9,7 @@ use crate::{state::{config_w, total_claimed_w},
             handle::{try_update_config, try_add_tasks, try_complete_task, try_create_account,
                      try_update_account, try_disable_permit_key, try_claim, try_claim_decay},
             query };
+use crate::state::decay_claimed_w;
 
 pub fn init<S: Storage, A: Api, Q: Querier>(
     deps: &mut Extern<S, A, Q>,
@@ -75,12 +76,15 @@ pub fn init<S: Storage, A: Api, Q: Querier>(
         merkle_root: msg.merkle_root,
         total_accounts: msg.total_accounts,
         max_amount: msg.max_amount,
+        redeem_step_size: msg.redeem_step_size
     };
 
     config_w(&mut deps.storage).save(&config)?;
 
     // Initialize claim amount
     total_claimed_w(&mut deps.storage).save(&Uint128::zero())?;
+
+    decay_claimed_w(&mut deps.storage).save(&false)?;
 
     Ok(InitResponse {
         messages: vec![],
@@ -119,10 +123,10 @@ pub fn query<S: Storage, A: Api, Q: Querier>(
     msg: QueryMsg,
 ) -> StdResult<Binary> {
     match msg {
-        QueryMsg::GetConfig { } => to_binary(&query::config(&deps)?),
-        QueryMsg::GetDates { current_date } => to_binary(&query::dates(&deps, current_date)?),
+        QueryMsg::Config { } => to_binary(&query::config(&deps)?),
+        QueryMsg::Dates { current_date } => to_binary(&query::dates(&deps, current_date)?),
         QueryMsg::TotalClaimed {} => to_binary(&query::total_claimed(&deps)?),
-        QueryMsg::GetAccount { permit, current_date } => to_binary(
+        QueryMsg::Account { permit, current_date } => to_binary(
             &query::account(&deps, permit, current_date)?),
     }
 }

--- a/contracts/airdrop/src/contract.rs
+++ b/contracts/airdrop/src/contract.rs
@@ -76,7 +76,7 @@ pub fn init<S: Storage, A: Api, Q: Querier>(
         merkle_root: msg.merkle_root,
         total_accounts: msg.total_accounts,
         max_amount: msg.max_amount,
-        redeem_step_size: msg.redeem_step_size
+        query_rounding: msg.query_rounding
     };
 
     config_w(&mut deps.storage).save(&config)?;
@@ -99,9 +99,9 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
 ) -> StdResult<HandleResponse> {
     match msg {
         HandleMsg::UpdateConfig {
-            admin, dump_address,
+            admin, dump_address, query_rounding: redeem_step_size,
             start_date, end_date, decay_start: start_decay
-        } => try_update_config(deps, env, admin, dump_address,
+        } => try_update_config(deps, env, admin, dump_address, redeem_step_size,
                                start_date, end_date, start_decay),
         HandleMsg::AddTasks { tasks
         } => try_add_tasks(deps, &env, tasks),

--- a/contracts/airdrop/src/handle.rs
+++ b/contracts/airdrop/src/handle.rs
@@ -11,6 +11,7 @@ pub fn try_update_config<S: Storage, A: Api, Q: Querier>(
     env: Env,
     admin: Option<HumanAddr>,
     dump_address: Option<HumanAddr>,
+    query_rounding: Option<Uint128>,
     start_date: Option<u64>,
     end_date: Option<u64>,
     decay_start: Option<u64>
@@ -29,6 +30,9 @@ pub fn try_update_config<S: Storage, A: Api, Q: Querier>(
         }
         if let Some(dump_address)= dump_address {
             state.dump_address = Some(dump_address);
+        }
+        if let Some(query_rounding)= query_rounding {
+            state.query_rounding = query_rounding;
         }
         if let Some(start_date) = start_date {
             // Avoid date collisions

--- a/contracts/airdrop/src/handle.rs
+++ b/contracts/airdrop/src/handle.rs
@@ -1,10 +1,6 @@
 use cosmwasm_std::{to_binary, Api, Env, Extern, HandleResponse, Querier, StdError, StdResult, Storage, HumanAddr, Uint128, Binary, Decimal};
 use rs_merkle::{Hasher, MerkleProof, algorithms::Sha256};
-use crate::state::{
-    config_r, config_w, claim_status_w, claim_status_r, account_total_claimed_w,
-    total_claimed_w, total_claimed_r, account_r, address_in_account_w, account_w, validate_address_permit,
-    revoke_permit
-};
+use crate::state::{config_r, config_w, claim_status_w, claim_status_r, account_total_claimed_w, total_claimed_w, total_claimed_r, account_r, address_in_account_w, account_w, validate_address_permit, revoke_permit, decay_claimed_w};
 use shade_protocol::{airdrop::{HandleAnswer, Config, claim_info::{RequiredTask},
                                account::{Account, AddressProofPermit}},
                      generic_response::ResponseStatus};
@@ -362,6 +358,15 @@ pub fn try_claim_decay<S: Storage, A: Api, Q: Querier>(
     if let Some(end_date) = config.end_date {
         if let Some(dump_address) = config.dump_address {
             if env.block.time > end_date {
+                decay_claimed_w(&mut deps.storage).update(| claimed | {
+                    if claimed {
+                        return Err(StdError::generic_err("Decay already claimed"))
+                    }
+                    else {
+                        Ok(true)
+                    }
+                })?;
+
                 let send_total = (config.airdrop_amount - total_claimed_r(&deps.storage).load()?)?;
                 let messages = vec![send_msg(
                     dump_address, send_total, None, None,

--- a/contracts/airdrop/src/query.rs
+++ b/contracts/airdrop/src/query.rs
@@ -1,5 +1,6 @@
 use cosmwasm_std::{Api, Extern, Querier, StdResult, Storage, Uint128};
 use shade_protocol::airdrop::{QueryAnswer, account::AccountPermit, claim_info::RequiredTask};
+use shade_protocol::math::{div, mult};
 use crate::handle::decay_factor;
 use crate::state::{config_r, claim_status_r, total_claimed_r, account_r, account_total_claimed_r, validate_account_permit, decay_claimed_r};
 
@@ -34,8 +35,7 @@ pub fn total_claimed<S: Storage, A: Api, Q: Querier>
     }
     else {
         let config = config_r(&deps.storage).load()?;
-        claimed = total_claimed.multiply_ratio(Uint128(1), config.redeem_step_size)
-            .multiply_ratio(config.redeem_step_size, Uint128(1));
+        claimed = mult(div(total_claimed, config.query_rounding)?, config.query_rounding);
     }
     Ok(QueryAnswer::TotalClaimed {
         claimed

--- a/contracts/airdrop/src/state.rs
+++ b/contracts/airdrop/src/state.rs
@@ -4,6 +4,7 @@ use cosmwasm_storage::{singleton, singleton_read, ReadonlySingleton, Singleton,
 use shade_protocol::airdrop::{Config, account::{Account, AccountPermit, AddressProofPermit, authenticate_ownership}};
 
 pub static CONFIG_KEY: &[u8] = b"config";
+pub static DECAY_CLAIMED_KEY: &[u8] = b"decay_claimed";
 pub static CLAIM_STATUS_KEY: &[u8] = b"claim_status_";
 pub static REWARD_IN_ACCOUNT_KEY: &[u8] = b"reward_in_account";
 pub static ACCOUNTS_KEY: &[u8] = b"accounts";
@@ -17,6 +18,14 @@ pub fn config_w<S: Storage>(storage: &mut S) -> Singleton<S, Config> {
 
 pub fn config_r<S: Storage>(storage: &S) -> ReadonlySingleton<S, Config> {
     singleton_read(storage, CONFIG_KEY)
+}
+
+pub fn decay_claimed_w<S: Storage>(storage: &mut S) -> Singleton<S, bool> {
+    singleton(storage, DECAY_CLAIMED_KEY)
+}
+
+pub fn decay_claimed_r<S: Storage>(storage: &S) -> ReadonlySingleton<S, bool> {
+    singleton_read(storage, DECAY_CLAIMED_KEY)
 }
 
 // Is address added to an account

--- a/contracts/airdrop/src/test.rs
+++ b/contracts/airdrop/src/test.rs
@@ -5,6 +5,7 @@ pub mod tests {
     use shade_protocol::{airdrop::{account::{AddressProofMsg, AddressProofPermit},
                                    claim_info::RequiredTask, InitMsg}, asset::Contract};
     use flexible_permits::{transaction::{PermitSignature, PubKey}, permit::bech32_to_canonical};
+    use shade_protocol::math::{div, mult};
     use crate::{handle::inverse_normalizer, contract::init};
 
     #[test]
@@ -103,19 +104,17 @@ pub mod tests {
 
     #[test]
     fn claim_query() {
-        assert_eq!(Uint128(300), Uint128(345).multiply_ratio(Uint128(1), Uint128(100))
-            .multiply_ratio(Uint128(100), Uint128(1)))
+
+        assert_eq!(Uint128(300), mult(div(Uint128(345), Uint128(100)).unwrap(), Uint128(100)))
     }
 
     #[test]
     fn claim_query_odd_multiple() {
-        assert_eq!(Uint128(13475), Uint128(13480).multiply_ratio(Uint128(1), Uint128(7))
-            .multiply_ratio(Uint128(7), Uint128(1)))
+        assert_eq!(Uint128(13475), mult(div(Uint128(13480), Uint128(7)).unwrap(), Uint128(7)))
     }
 
     #[test]
     fn claim_query_under_step() {
-        assert_eq!(Uint128(0), Uint128(200).multiply_ratio(Uint128(1), Uint128(1000))
-            .multiply_ratio(Uint128(1000), Uint128(1)))
+        assert_eq!(Uint128(0), mult(div(Uint128(200), Uint128(1000)).unwrap(), Uint128(1000)))
     }
 }

--- a/contracts/airdrop/src/test.rs
+++ b/contracts/airdrop/src/test.rs
@@ -101,5 +101,21 @@ pub mod tests {
         assert_ne!(permit_addr.as_canonical(), bech32_to_canonical("terra19m2zgdyuq0crpww00jc2a9k70ut944dum53p7x"));
     }
 
+    #[test]
+    fn claim_query() {
+        assert_eq!(Uint128(300), Uint128(345).multiply_ratio(Uint128(1), Uint128(100))
+            .multiply_ratio(Uint128(100), Uint128(1)))
+    }
 
+    #[test]
+    fn claim_query_odd_multiple() {
+        assert_eq!(Uint128(13475), Uint128(13480).multiply_ratio(Uint128(1), Uint128(7))
+            .multiply_ratio(Uint128(7), Uint128(1)))
+    }
+
+    #[test]
+    fn claim_query_under_step() {
+        assert_eq!(Uint128(0), Uint128(200).multiply_ratio(Uint128(1), Uint128(1000))
+            .multiply_ratio(Uint128(1000), Uint128(1)))
+    }
 }

--- a/packages/network_integration/src/testnet_airdrop.rs
+++ b/packages/network_integration/src/testnet_airdrop.rs
@@ -108,7 +108,8 @@ fn main() -> Result<()> {
         default_claim: Uint128(20),
         task_claim: vec![RequiredTask {
             address: HumanAddr::from(account_addr.clone()),
-            percent: Uint128(50) }]
+            percent: Uint128(50) }],
+        redeem_step_size: Uint128(10000000000)
     };
 
     let airdrop = test_inst_init(&airdrop_init_msg, AIRDROP_FILE,

--- a/packages/network_integration/src/testnet_airdrop.rs
+++ b/packages/network_integration/src/testnet_airdrop.rs
@@ -109,7 +109,7 @@ fn main() -> Result<()> {
         task_claim: vec![RequiredTask {
             address: HumanAddr::from(account_addr.clone()),
             percent: Uint128(50) }],
-        redeem_step_size: Uint128(10000000000)
+        query_rounding: Uint128(10000000000)
     };
 
     let airdrop = test_inst_init(&airdrop_init_msg, AIRDROP_FILE,

--- a/packages/network_integration/tests/testnet_integration.rs
+++ b/packages/network_integration/tests/testnet_integration.rs
@@ -164,7 +164,8 @@ fn run_airdrop() -> Result<()> {
         default_claim: Uint128(50),
         task_claim: vec![RequiredTask {
             address: HumanAddr::from(account_a.clone()),
-            percent: Uint128(50) }]
+            percent: Uint128(50) }],
+        redeem_step_size: Uint128(30000000)
     };
 
     let airdrop = test_inst_init(&airdrop_init_msg, AIRDROP_FILE, &*generate_label(8),
@@ -225,7 +226,7 @@ fn run_airdrop() -> Result<()> {
 
     print_warning("Getting initial account information");
     {
-        let msg = airdrop::QueryMsg::GetAccount {
+        let msg = airdrop::QueryMsg::Account {
             permit: account_permit.clone(),
             current_date: None
         };
@@ -252,7 +253,7 @@ fn run_airdrop() -> Result<()> {
                          Some("test"), None)?;
 
     {
-        let msg = airdrop::QueryMsg::GetAccount {
+        let msg = airdrop::QueryMsg::Account {
             permit: account_permit.clone(),
             current_date: None
         };
@@ -265,6 +266,18 @@ fn run_airdrop() -> Result<()> {
             assert_eq!(claimed, ab_half_airdrop);
             assert_eq!(unclaimed, ab_half_airdrop);
             assert_eq!(finished_tasks.len(), 2);
+        }
+    }
+
+    print_warning("Verifying query step functionality");
+
+    {
+        let msg = airdrop::QueryMsg::TotalClaimed { };
+
+        let query: airdrop::QueryAnswer = query_contract(&airdrop, msg)?;
+
+        if let airdrop::QueryAnswer::TotalClaimed { claimed } = query {
+            assert_eq!(claimed, Uint128(30000000));
         }
     }
 
@@ -290,7 +303,7 @@ fn run_airdrop() -> Result<()> {
 
     /// Query that all of the airdrop is claimed
     {
-        let msg = airdrop::QueryMsg::GetAccount {
+        let msg = airdrop::QueryMsg::Account {
             permit: account_permit.clone(),
             current_date: None
         };
@@ -312,7 +325,7 @@ fn run_airdrop() -> Result<()> {
                          Some("test"), None)?;
 
     {
-        let msg = airdrop::QueryMsg::GetAccount {
+        let msg = airdrop::QueryMsg::Account {
             permit: account_permit.clone(),
             current_date: None
         };
@@ -329,7 +342,7 @@ fn run_airdrop() -> Result<()> {
             key: "new_key".to_string() }, ACCOUNT_KEY);
 
     {
-        let msg = airdrop::QueryMsg::GetAccount {
+        let msg = airdrop::QueryMsg::Account {
             permit: new_account_permit.clone(),
             current_date: None
         };
@@ -376,6 +389,8 @@ fn run_airdrop() -> Result<()> {
         assert!(balance < total_airdrop + decay_amount);
     }
 
+    let pre_decay_balance = get_balance(&snip, account_a.clone());
+
     /// Try to claim expired tokens
     print_warning("Claiming expired tokens");
     {
@@ -389,6 +404,18 @@ fn run_airdrop() -> Result<()> {
                          Some("test"), None)?;
 
     assert_eq!(total_airdrop + decay_amount, get_balance(&snip, account_a.clone()));
+
+    print_warning("Verifying query step functionality after decay claim");
+
+    {
+        let msg = airdrop::QueryMsg::TotalClaimed { };
+
+        let query: airdrop::QueryAnswer = query_contract(&airdrop, msg)?;
+
+        if let airdrop::QueryAnswer::TotalClaimed { claimed } = query {
+            assert_eq!(claimed, pre_decay_balance);
+        }
+    }
 
     Ok(())
 }

--- a/packages/network_integration/tests/testnet_integration.rs
+++ b/packages/network_integration/tests/testnet_integration.rs
@@ -165,7 +165,7 @@ fn run_airdrop() -> Result<()> {
         task_claim: vec![RequiredTask {
             address: HumanAddr::from(account_a.clone()),
             percent: Uint128(50) }],
-        redeem_step_size: Uint128(30000000)
+        query_rounding: Uint128(30000000)
     };
 
     let airdrop = test_inst_init(&airdrop_init_msg, AIRDROP_FILE, &*generate_label(8),

--- a/packages/shade_protocol/src/airdrop/mod.rs
+++ b/packages/shade_protocol/src/airdrop/mod.rs
@@ -32,7 +32,9 @@ pub struct Config {
     // tree height
     pub total_accounts: u32,
     // max possible reward amount; used to prevent collision possibility
-    pub max_amount: Uint128
+    pub max_amount: Uint128,
+    // Protects from leaking user information by limiting amount detail
+    pub redeem_step_size: Uint128
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -58,7 +60,9 @@ pub struct InitMsg {
     // Default gifted amount
     pub default_claim: Uint128,
     // The task related claims
-    pub task_claim: Vec<RequiredTask>
+    pub task_claim: Vec<RequiredTask>,
+    // Protects from leaking user information by limiting amount detail
+    pub redeem_step_size: Uint128
 }
 
 impl InitCallback for InitMsg {
@@ -115,10 +119,10 @@ pub enum HandleAnswer {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
-    GetConfig { },
-    GetDates { current_date: Option<u64> },
+    Config { },
+    Dates { current_date: Option<u64> },
     TotalClaimed { },
-    GetAccount { permit: AccountPermit, current_date: Option<u64> },
+    Account { permit: AccountPermit, current_date: Option<u64> },
 }
 
 impl Query for QueryMsg {

--- a/packages/shade_protocol/src/airdrop/mod.rs
+++ b/packages/shade_protocol/src/airdrop/mod.rs
@@ -34,7 +34,7 @@ pub struct Config {
     // max possible reward amount; used to prevent collision possibility
     pub max_amount: Uint128,
     // Protects from leaking user information by limiting amount detail
-    pub redeem_step_size: Uint128
+    pub query_rounding: Uint128
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -62,7 +62,7 @@ pub struct InitMsg {
     // The task related claims
     pub task_claim: Vec<RequiredTask>,
     // Protects from leaking user information by limiting amount detail
-    pub redeem_step_size: Uint128
+    pub query_rounding: Uint128
 }
 
 impl InitCallback for InitMsg {
@@ -75,6 +75,7 @@ pub enum HandleMsg {
     UpdateConfig {
         admin: Option<HumanAddr>,
         dump_address: Option<HumanAddr>,
+        query_rounding: Option<Uint128>,
         start_date: Option<u64>,
         end_date: Option<u64>,
         decay_start: Option<u64>,

--- a/packages/shade_protocol/src/lib.rs
+++ b/packages/shade_protocol/src/lib.rs
@@ -4,6 +4,7 @@ pub mod generic_response;
 pub mod secretswap;
 pub mod band;
 pub mod snip20;
+pub mod math;
 
 // Protocol init libraries
 pub mod initializer;

--- a/packages/shade_protocol/src/math.rs
+++ b/packages/shade_protocol/src/math.rs
@@ -1,0 +1,40 @@
+use cosmwasm_std::{StdError, StdResult, Uint128};
+
+// Non permanent solutions to Uint128 issues
+
+pub fn mult(a: Uint128, b: Uint128) -> Uint128 {
+    if a.is_zero() || b.is_zero() {
+        return Uint128::zero();
+    }
+
+    Uint128(a.u128() * b.u128())
+}
+
+pub fn div(nom: Uint128, den: Uint128) -> StdResult<Uint128> {
+    if den == Uint128::zero() {
+        return Err(StdError::generic_err("Division by 0"))
+    }
+
+    Ok(Uint128(nom.u128() / den.u128()))
+}
+
+#[cfg(test)]
+pub mod tests {
+    use cosmwasm_std::Uint128;
+    use crate::math::{div, mult};
+
+    #[test]
+    fn multiply() {
+        assert_eq!(Uint128(10), mult(Uint128(5), Uint128(2)))
+    }
+
+    #[test]
+    fn divide() {
+        assert_eq!(Uint128(5), div(Uint128(10), Uint128(2)).unwrap())
+    }
+
+    #[test]
+    fn divide_by_zero() {
+        assert!(div(Uint128(10), Uint128(0)).is_err())
+    }
+}


### PR DESCRIPTION
Since total claimed amount is public, malicious nodes can query this information and calculate user claimed amounts. Query now has a rounding or step amount to protect against it. Once the airdrop ```end_date``` is reached and decay amount is claimed then the real amount is exposed.