### PR TITLE
Oracle remove hardcoded

### DIFF
--- a/contracts/mock_band/src/contract.rs
+++ b/contracts/mock_band/src/contract.rs
@@ -50,8 +50,6 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
             return Ok(HandleResponse::default())
         }
     }
-
-    Err(StdError::GenericErr { msg: "Not Implemented".to_string(), backtrace: None})
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/contracts/oracle/src/contract.rs
+++ b/contracts/oracle/src/contract.rs
@@ -11,7 +11,7 @@ use shade_protocol::{
     band::ReferenceData,
 };
 use crate::{
-    state::{ config_w, hard_coded_w },
+    state::{ config_w },
     query, handle,
 };
 
@@ -30,15 +30,6 @@ pub fn init<S: Storage, A: Api, Q: Querier>(
     };
 
     config_w(&mut deps.storage).save(&state)?;
-
-    /* Hard-coded SILK = $1.00
-     */
-    hard_coded_w(&mut deps.storage).save("SILK".as_bytes(), &ReferenceData {
-                //1$
-                rate: Uint128(1 * 10u128.pow(18)),
-                last_updated_base: 0,
-                last_updated_quote: 0
-            })?;
 
     debug_print!("Contract was initialized by {}", env.message.sender);
 

--- a/contracts/oracle/src/query.rs
+++ b/contracts/oracle/src/query.rs
@@ -42,12 +42,6 @@ pub fn price<S: Storage, A: Api, Q: Querier>(
         return reference_data(deps, "SCRT".to_string(), "USD".to_string());
     }
 
-    /*
-    if let Some(reference_data) = hard_coded_r(&deps.storage).may_load(&symbol.as_bytes())? {
-        return Ok(reference_data);
-    }
-    */
-
     // secret swap pair
     // TODO: sienna pair
     if let Some(sswap_pair) = sswap_pairs_r(&deps.storage).may_load(symbol.as_bytes())? {

--- a/contracts/oracle/src/state.rs
+++ b/contracts/oracle/src/state.rs
@@ -17,7 +17,6 @@ use shade_protocol::{
 };
 
 pub static CONFIG_KEY: &[u8] = b"config";
-pub static HARD_CODED: &[u8] = b"hard_coded";
 pub static SSWAP_PAIRS: &[u8] = b"sswap_pairs";
 pub static INDEX: &[u8] = b"index";
 
@@ -27,14 +26,6 @@ pub fn config_r<S: Storage>(storage: &S) -> ReadonlySingleton<S, OracleConfig> {
 
 pub fn config_w<S: Storage>(storage: &mut S) -> Singleton<S, OracleConfig> {
     singleton(storage, CONFIG_KEY)
-}
-
-pub fn hard_coded_r<S: Storage>(storage: &S) -> ReadonlyBucket<S, ReferenceData> {
-    bucket_read(HARD_CODED, storage)
-}
-
-pub fn hard_coded_w<S: Storage>(storage: &mut S) -> Bucket<S, ReferenceData> {
-    bucket(HARD_CODED, storage)
 }
 
 pub fn sswap_pairs_r<S: Storage>(storage: &S) -> ReadonlyBucket<S, SswapPair> {


### PR DESCRIPTION
Just some tidying up, 'mock-band' had an unreachable expression and the hard coded prices in oracle are no longer needed.