### PR TITLE
changed capture to p*(10^18)

### DIFF
--- a/contracts/micro_mint/src/handle.rs
+++ b/contracts/micro_mint/src/handle.rs
@@ -509,7 +509,7 @@ pub fn calculate_capture(amount: Uint128, capture: Uint128) -> Uint128 {
      * capture_amount = amount * capture / 10000
      */
 
-    amount.multiply_ratio(capture, 10000u128)
+    amount.multiply_ratio(capture, 10u128.pow(18))
 }
 
 fn oracle<S: Storage, A: Api, Q: Querier>(

--- a/contracts/micro_mint/src/test.rs
+++ b/contracts/micro_mint/src/test.rs
@@ -365,7 +365,7 @@ pub mod tests {
     fn capture_calc() {
         let amount = Uint128(1_000_000_000_000_000_000);
         //10%
-        let capture = Uint128(1000);
+        let capture = Uint128(100_000_000_000_000_000);
         let expected = Uint128(100_000_000_000_000_000);
         let value = calculate_capture(amount, capture);
         assert_eq!(value, expected);


### PR DESCRIPTION
Slight adjustment to mint capture so it uses 'capture *10^18` for the percentage in the same format as other decimals.