### PR TITLE
Airdrop | HandleMsg output bug

### DIFF
--- a/contracts/airdrop/src/handle.rs
+++ b/contracts/airdrop/src/handle.rs
@@ -259,7 +259,6 @@ pub fn try_account<S: Storage, A: Api, Q: Querier>(
         )?;
     }
 
-    let mut user_claimed = Uint128::zero();
     if updating_account && completed_percentage > Uint128::zero() {
         // Calculate the total new address amount
         let added_address_total = (account.total_claimable - old_claim_amount)?;
@@ -275,8 +274,7 @@ pub fn try_account<S: Storage, A: Api, Q: Querier>(
                 }
 
                 redeem_amount += new_redeem;
-                user_claimed = claimed + new_redeem;
-                Ok(user_claimed)
+                Ok(claimed + new_redeem)
             } else {
                 Err(unexpected_error())
             }
@@ -307,9 +305,8 @@ pub fn try_account<S: Storage, A: Api, Q: Querier>(
         data: Some(to_binary(&HandleAnswer::Account {
             status: ResponseStatus::Success,
             total: account.total_claimable,
-            claimed: user_claimed,
+            claimed: account_total_claimed_r(&deps.storage).load(sender.to_string().as_bytes())?,
             // Will always be 0 since rewards are automatically claimed here
-            unclaimed: Uint128::zero(),
             finished_tasks: finished_tasks(&deps.storage, sender.clone())?,
             addresses: account.addresses,
         })?),
@@ -431,7 +428,6 @@ pub fn try_claim<S: Storage, A: Api, Q: Querier>(
             status: ResponseStatus::Success,
             total: account.total_claimable,
             claimed: account_total_claimed_r(&deps.storage).load(sender.to_string().as_bytes())?,
-            unclaimed: Uint128::zero(),
             finished_tasks: finished_tasks(&deps.storage, sender.to_string())?,
             addresses: account.addresses,
         })?),

--- a/packages/shade_protocol/src/airdrop/mod.rs
+++ b/packages/shade_protocol/src/airdrop/mod.rs
@@ -138,8 +138,6 @@ pub enum HandleAnswer {
         total: Uint128,
         // Total claimed
         claimed: Uint128,
-        // Total unclaimed but available
-        unclaimed: Uint128,
         finished_tasks: Vec<RequiredTask>,
         // Addresses claimed
         addresses: Vec<HumanAddr>,
@@ -156,8 +154,6 @@ pub enum HandleAnswer {
         total: Uint128,
         // Total claimed
         claimed: Uint128,
-        // Total unclaimed but available
-        unclaimed: Uint128,
         finished_tasks: Vec<RequiredTask>,
         // Addresses claimed
         addresses: Vec<HumanAddr>,


### PR DESCRIPTION
<!-- NOTE: Listed items are examples and should be removed when making a PR -->

# Description
The claimed amount being returned by the `account` HandleMsg was tied to account updating and not creation, resulting in it outputting `0` every time an account was creating. (Non breaking)

## Notable changes

<!-- List what the notable changes are -->

- Fixed `claimed` parameter returned in `account` and `claim` HandleMsgs
- Removed `unclaimed` from `account` and `claim` since theyre always going to be `0`
