### PR TITLE
remove unclaimed

### DIFF
--- a/contracts/airdrop/README.md
+++ b/contracts/airdrop/README.md
@@ -140,7 +140,6 @@ Complete that address' tasks for a given user
     "status": "success",
     "total": "Total airdrop amount",
     "claimed": "Claimed amount",
-    "unclaimed": "Amount available to claim",
     "finished_tasks": "All of the finished tasks",
     "addresses": ["claimed addresses"]
   }
@@ -191,7 +190,6 @@ Claim the user's available claimable amount
     "status": "success",
     "total": "Total airdrop amount",
     "claimed": "Claimed amount",
-    "unclaimed": "Amount available to claim",
     "finished_tasks": "All of the finished tasks",
     "addresses": ["claimed addresses"]
   }


### PR DESCRIPTION
# Description

Documentation Update: Removed "unclaimed" from response data of Account and Claim transactions.
