### PR TITLE
now runs tests from root

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,7 +31,7 @@ jobs:
           toolchain: stable
           target: wasm32-unknown-unknown
 
-      - uses: actions-rs/cargo@v1.0.1
+      - uses: actions-rs/cargo@v1.0.3
         with:
           command: build
           args: --release --target wasm32-unknown-unknown --manifest-path=${{matrix.dir}}
@@ -48,7 +48,7 @@ jobs:
           toolchain: stable
           target: wasm32-unknown-unknown
 
-      - uses: actions-rs/cargo@v1.0.1
+      - uses: actions-rs/cargo@v1.0.3
         with:
           command: test
           args: --manifest-path=Cargo.toml

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,6 @@ jobs:
       matrix:
         dir: ${{fromJson(needs.find_contracts.outputs.dir)}} # List matrix strategy from directories dynamically
     steps:
-
       - uses: actions/checkout@v2
         with:
           submodules: recursive
@@ -37,7 +36,20 @@ jobs:
           command: build
           args: --release --target wasm32-unknown-unknown --manifest-path=${{matrix.dir}}
           
+  test-all:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+
       - uses: actions-rs/cargo@v1.0.1
         with:
           command: test
-          args: --manifest-path=${{matrix.dir}}
+          args: --manifest-path=Cargo.toml
+


### PR DESCRIPTION
Now runs `cargo test` from root of project instead of per-contract so it includes tests in `packages`