### PR TITLE
Snip20 staking math update

### DIFF
--- a/contracts/snip20_staking/Cargo.toml
+++ b/contracts/snip20_staking/Cargo.toml
@@ -48,9 +48,6 @@ sha2 = { version = "0.9.1", default-features = false }
 shade-protocol = { version = "0.1.0", path = "../../packages/shade_protocol", features = ["snip20_staking", "snip20", "storage"] }
 cosmwasm-math-compat = { version = "0.1.0", path = "../../packages/cosmwasm_math_compat" }
 
-# Large number math
-ethnum = "1.1.1"
-
 [dev-dependencies]
 cosmwasm-schema = { version = "0.9.2" }
 rand = "0.8.4"

--- a/contracts/snip20_staking/src/batch.rs
+++ b/contracts/snip20_staking/src/batch.rs
@@ -3,7 +3,8 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_std::{Binary, HumanAddr, Uint128};
+use cosmwasm_std::{Binary, HumanAddr};
+use cosmwasm_math_compat::Uint128;
 
 #[derive(Serialize, Deserialize, JsonSchema, Clone, Debug)]
 #[serde(rename_all = "snake_case")]

--- a/contracts/snip20_staking/src/expose_balance.rs
+++ b/contracts/snip20_staking/src/expose_balance.rs
@@ -7,9 +7,10 @@ use crate::state::{get_receiver_hash, Balances};
 use crate::state_staking::UserCooldown;
 use cosmwasm_std::{
     to_binary, Api, Binary, CosmosMsg, Env, Extern, HandleResponse, HumanAddr, Querier, StdError,
-    StdResult, Storage, Uint128,
+    StdResult, Storage,
 };
 use secret_toolkit::utils::HandleCallback;
+use cosmwasm_math_compat::Uint128;
 use shade_protocol::snip20_staking::stake::VecQueue;
 use shade_protocol::utils::storage::default::BucketStorage;
 
@@ -36,7 +37,7 @@ pub fn try_expose_balance<S: Storage, A: Api, Q: Querier>(
 
     let messages =
         vec![
-            Snip20BalanceReceiverMsg::new(env.message.sender, Uint128(balance), memo, msg)
+            Snip20BalanceReceiverMsg::new(env.message.sender, Uint128::new(balance), memo, msg)
                 .to_cosmos_msg(receiver_hash, recipient)?,
         ];
 
@@ -79,7 +80,7 @@ pub fn try_expose_balance_with_cooldown<S: Storage, A: Api, Q: Querier>(
 
     let messages = vec![Snip20BalanceReceiverMsg::new(
         env.message.sender,
-        (Uint128(balance) - cooldown.total)?,
+        Uint128::new(balance).checked_sub(cooldown.total)?,
         memo,
         msg,
     )

--- a/contracts/snip20_staking/src/msg.rs
+++ b/contracts/snip20_staking/src/msg.rs
@@ -6,8 +6,9 @@ use serde::{Deserialize, Serialize};
 use crate::batch;
 use crate::transaction_history::{RichTx, Tx};
 use crate::viewing_key::ViewingKey;
-use cosmwasm_std::{Binary, HumanAddr, StdError, StdResult, Uint128};
+use cosmwasm_std::{Binary, HumanAddr, StdError, StdResult};
 use secret_toolkit::permit::Permit;
+use cosmwasm_math_compat::{Uint128, Uint256};
 use shade_protocol::snip20_staking::stake::{QueueItem, StakeConfig, VecQueue};
 use shade_protocol::utils::asset::Contract;
 
@@ -409,15 +410,15 @@ pub enum QueryAnswer {
     },
     TotalStaked {
         tokens: Uint128,
-        shares: Uint128,
+        shares: Uint256,
     },
     // Shares per token
     StakeRate {
-        shares: Uint128,
+        shares: Uint256,
     },
     Staked {
         tokens: Uint128,
-        shares: Uint128,
+        shares: Uint256,
         pending_rewards: Uint128,
         unbonding: Uint128,
         unbonded: Option<Uint128>,

--- a/contracts/snip20_staking/src/receiver.rs
+++ b/contracts/snip20_staking/src/receiver.rs
@@ -3,7 +3,8 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_std::{to_binary, Binary, CosmosMsg, HumanAddr, StdResult, Uint128, WasmMsg};
+use cosmwasm_std::{to_binary, Binary, CosmosMsg, HumanAddr, StdResult, WasmMsg};
+use cosmwasm_math_compat::Uint128;
 
 use crate::{contract::RESPONSE_BLOCK_SIZE, msg::space_pad};
 

--- a/contracts/snip20_staking/src/stake.rs
+++ b/contracts/snip20_staking/src/stake.rs
@@ -1,3 +1,4 @@
+use std::convert::TryInto;
 use crate::contract::check_if_admin;
 use crate::msg::HandleAnswer;
 use crate::msg::ResponseStatus::Success;
@@ -12,9 +13,9 @@ use crate::transaction_history::{
 };
 use cosmwasm_std::{
     from_binary, to_binary, Api, Binary, CanonicalAddr, Decimal, Env, Extern,
-    HandleResponse, HumanAddr, Querier, StdError, StdResult, Storage, Uint128,
+    HandleResponse, HumanAddr, Querier, StdError, StdResult, Storage,
 };
-use ethnum::u256;
+use cosmwasm_math_compat::{Uint128, Uint256};
 use secret_toolkit::snip20::send_msg;
 use shade_protocol::snip20_staking::stake::{DailyUnbonding, StakeConfig, Unbonding, VecQueue};
 use shade_protocol::snip20_staking::ReceiveType;
@@ -46,11 +47,11 @@ pub fn try_update_stake_config<S: Storage, A: Api, Q: Querier>(
     } else if let Some(treasury) = treasury {
         stake_config.treasury = Some(treasury.clone());
 
-        let unsent_tokens = UnsentStakedTokens::load(&deps.storage)?;
-        if unsent_tokens.0 != Uint128::zero() {
+        let unsent_tokens = UnsentStakedTokens::load(&deps.storage)?.0;
+        if unsent_tokens != Uint128::zero() {
             messages.push(send_msg(
                 treasury,
-                unsent_tokens.0,
+                unsent_tokens.into(),
                 None,
                 None,
                 None,
@@ -90,16 +91,16 @@ fn add_balance<S: Storage>(
     stake_config: &StakeConfig,
     sender: &HumanAddr,
     sender_canon: &CanonicalAddr,
-    amount: u128,
+    amount: Uint128,
 ) -> StdResult<()> {
     // Check if user account exists
     let mut user_shares = UserShares::may_load(storage, sender.as_str().as_bytes())?
-        .unwrap_or(UserShares(Uint128::zero()));
+        .unwrap_or(UserShares(Uint256::zero()));
 
     // Update user staked tokens
     let mut balances = Balances::from_storage(storage);
     let mut account_balance = balances.balance(sender_canon);
-    if let Some(new_balance) = account_balance.checked_add(amount) {
+    if let Some(new_balance) = account_balance.checked_add(amount.u128()) {
         account_balance = new_balance;
     } else {
         return Err(StdError::generic_err(
@@ -114,28 +115,28 @@ fn add_balance<S: Storage>(
 
     // Update total staked
     // We do this before reaching shares to get overflows out of the way
-    if let Some(total_staked) = total_tokens.0.u128().checked_add(amount) {
-        TotalTokens(Uint128(total_staked)).save(storage)?;
-    } else {
-        return Err(StdError::generic_err("Total staked tokens overflow"));
-    }
+    match total_tokens.0.checked_add(amount) {
+        Ok(total_staked) => TotalTokens(total_staked).save(storage)?,
+        Err(_) => return Err(StdError::generic_err("Total staked tokens overflow"))
+    };
+
     let supply = ReadonlyConfig::from_storage(storage).total_supply();
-    Config::from_storage(storage).set_total_supply(supply + amount);
+    Config::from_storage(storage).set_total_supply(supply + amount.u128());
 
     // Calculate shares per token supplied
-    let shares = Uint128(shares_per_token(
+    let shares = shares_per_token(
         stake_config,
         &amount,
-        &total_tokens.0.u128(),
-        &total_shares.0.u128(),
-    )?);
+        &total_tokens.0,
+        &total_shares.0,
+    )?;
 
     // Update total shares
-    if let Some(total_added_shares) = total_shares.0.u128().checked_add(shares.u128()) {
-        total_shares = TotalShares(Uint128(total_added_shares));
-    } else {
-        return Err(StdError::generic_err("Shares overflow"));
-    }
+    match total_shares.0.checked_add(shares) {
+        Ok(total_added_shares) => total_shares = TotalShares(total_added_shares),
+        Err(_) => return Err(StdError::generic_err("Shares overflow"))
+    };
+
     total_shares.save(storage)?;
 
     // Update user's shares - this will not break as total_shares >= user_shares
@@ -151,27 +152,26 @@ fn add_balance<S: Storage>(
 fn subtract_internal_supply<S: Storage>(
     storage: &mut S,
     total_shares: &mut TotalShares,
-    shares: u128,
+    shares: Uint256,
     total_tokens: &mut TotalTokens,
-    tokens: u128,
+    tokens: Uint128,
     remove_supply: bool,
 ) -> StdResult<()> {
     // Update total shares
-    if let Some(total) = total_shares.0.u128().checked_sub(shares) {
-        TotalShares(Uint128(total)).save(storage)?;
-    } else {
-        return Err(StdError::generic_err("Insufficient shares"));
-    }
+    match total_shares.0.checked_sub(shares) {
+        Ok(total) => TotalShares(total).save(storage)?,
+        Err(_) => return Err(StdError::generic_err("Insufficient shares"))
+    };
 
     // Update total staked
-    if let Some(total) = total_tokens.0.u128().checked_sub(tokens) {
-        TotalTokens(Uint128(total)).save(storage)?;
-    } else {
-        return Err(StdError::generic_err("Insufficient tokens"));
-    }
+    match total_tokens.0.checked_sub(tokens) {
+        Ok(total) => TotalTokens(total).save(storage)?,
+        Err(_) => return Err(StdError::generic_err("Insufficient tokens"))
+    };
+
     if remove_supply {
         let supply = ReadonlyConfig::from_storage(storage).total_supply();
-        if let Some(total) = supply.checked_sub(tokens) {
+        if let Some(total) = supply.checked_sub(tokens.u128()) {
             Config::from_storage(storage).set_total_supply(total);
         } else {
             return Err(StdError::generic_err("Insufficient shares"));
@@ -189,7 +189,7 @@ fn remove_balance<S: Storage>(
     stake_config: &StakeConfig,
     account: &HumanAddr,
     account_cannon: &CanonicalAddr,
-    amount: u128,
+    amount: Uint128,
     time: u64,
 ) -> StdResult<()> {
     // Return insufficient funds
@@ -204,15 +204,14 @@ fn remove_balance<S: Storage>(
     let shares = shares_per_token(
         stake_config,
         &amount,
-        &total_tokens.0.u128(),
-        &total_shares.0.u128(),
+        &total_tokens.0,
+        &total_shares.0,
     )?;
 
     // Update user's shares
-    if let Some(user_shares) = user_shares.0.u128().checked_sub(shares) {
-        UserShares(Uint128(user_shares)).save(storage, account.as_str().as_bytes())?;
-    } else {
-        return Err(StdError::generic_err("Insufficient shares"));
+    match user_shares.0.checked_sub(shares) {
+        Ok(user_shares) => UserShares(user_shares).save(storage, account.as_str().as_bytes())?,
+        Err(_) => return Err(StdError::generic_err("Insufficient shares"))
     }
 
     subtract_internal_supply(
@@ -229,7 +228,7 @@ fn remove_balance<S: Storage>(
     let mut account_balance = balances.balance(account_cannon);
     let account_tokens = account_balance;
 
-    if let Some(new_balance) = account_balance.checked_sub(amount) {
+    if let Some(new_balance) = account_balance.checked_sub(amount.u128()) {
         account_balance = new_balance;
     } else {
         return Err(StdError::generic_err(
@@ -240,8 +239,8 @@ fn remove_balance<S: Storage>(
     remove_from_cooldown(
         storage,
         account,
-        Uint128(account_tokens),
-        Uint128(amount),
+        Uint128::new(account_tokens),
+        amount,
         time,
     )?;
     Ok(())
@@ -252,7 +251,7 @@ pub fn claim_rewards<S: Storage>(
     stake_config: &StakeConfig,
     sender: &HumanAddr,
     sender_canon: &CanonicalAddr,
-) -> StdResult<u128> {
+) -> StdResult<Uint128> {
     let user_shares =
         UserShares::may_load(storage, sender.as_str().as_bytes())?.expect("No funds");
 
@@ -264,22 +263,21 @@ pub fn claim_rewards<S: Storage>(
 
     let (reward_token, reward_shares) = calculate_rewards(
         stake_config,
-        user_balance,
-        user_shares.0.u128(),
-        total_tokens.0.u128(),
-        total_shares.0.u128(),
+        Uint128::new(user_balance),
+        user_shares.0,
+        total_tokens.0,
+        total_shares.0,
     )?;
 
     // Do nothing if no rewards are gonna be claimed
-    if reward_token == 0 {
+    if reward_token.is_zero() {
         return Ok(reward_token);
     }
 
-    if let Some(user_shares) = user_shares.0.u128().checked_sub(reward_shares) {
-        UserShares(Uint128(user_shares)).save(storage, sender.as_str().as_bytes())?;
-    } else {
-        return Err(StdError::generic_err("Insufficient shares"));
-    }
+    match user_shares.0.checked_sub(reward_shares) {
+        Ok(user_shares) => UserShares(user_shares).save(storage, sender.as_str().as_bytes())?,
+        Err(_) => return Err(StdError::generic_err("Insufficient shares"))
+    };
 
     subtract_internal_supply(
         storage,
@@ -295,56 +293,56 @@ pub fn claim_rewards<S: Storage>(
 
 pub fn shares_per_token(
     config: &StakeConfig,
-    token_amount: &u128,
-    total_tokens: &u128,
-    total_shares: &u128,
-) -> StdResult<u128> {
-    let t_tokens = u256::from(*total_tokens);
-    let t_shares = u256::from(*total_shares);
-    let tokens = u256::from(*token_amount);
+    token_amount: &Uint128,
+    total_tokens: &Uint128,
+    total_shares: &Uint256,
+) -> StdResult<Uint256> {
+    let t_tokens = Uint256::from(*total_tokens);
+    let t_shares = *total_shares;
+    let tokens = Uint256::from(*token_amount);
 
-    if *total_tokens == 0 && *total_shares == 0 {
+    if total_tokens.is_zero() && total_shares.is_zero() {
         // Used to normalize the staked token to the stake token
-        let token_multiplier = u256::from(10u16).pow(config.decimal_difference.into());
-        if let Some(shares) = tokens.checked_mul(token_multiplier) {
-            return Ok(shares.as_u128());
-        } else {
-            return Err(StdError::generic_err("Share calculation overflow"));
-        }
+        let token_multiplier = Uint256::from(10u128)
+            .checked_pow(config.decimal_difference.into())?;
+
+        return match tokens.checked_mul(token_multiplier) {
+            Ok(shares) => Ok(shares),
+            Err(_) => Err(StdError::generic_err("Share calculation overflow"))
+        };
     }
 
-    if let Some(shares) = tokens.checked_mul(t_shares) {
-        return Ok((shares / t_tokens).as_u128());
-    } else {
-        return Err(StdError::generic_err("Share calculation overflow"));
-    }
+    return match tokens.checked_mul(t_shares) {
+        Ok(shares) => Ok(shares.checked_div(t_tokens)?),
+        Err(_) => Err(StdError::generic_err("Share calculation overflow"))
+    };
 }
 
 pub fn tokens_per_share(
     config: &StakeConfig,
-    shares_amount: &u128,
-    total_tokens: &u128,
-    total_shares: &u128,
-) -> StdResult<u128> {
-    let t_tokens = u256::from(*total_tokens);
-    let t_shares = u256::from(*total_shares);
-    let shares = u256::from(*shares_amount);
+    shares_amount: &Uint256,
+    total_tokens: &Uint128,
+    total_shares: &Uint256,
+) -> StdResult<Uint128> {
+    let t_tokens = Uint256::from(*total_tokens);
+    let t_shares = *total_shares;
+    let shares = *shares_amount;
 
-    if *total_tokens == 0 && *total_shares == 0 {
+    if total_tokens.is_zero() && total_shares.is_zero() {
         // Used to normalize the staked token to the stake tokes
-        let token_multiplier = u256::from(10u16).pow(config.decimal_difference.into());
-        if let Some(tokens) = shares.checked_div(token_multiplier) {
-            return Ok(tokens.as_u128());
-        } else {
-            return Err(StdError::generic_err("Token calculation overflow"));
-        }
+        let token_multiplier = Uint256::from(10u128)
+            .checked_pow(config.decimal_difference.try_into().unwrap())?;
+
+        return match shares.checked_div(token_multiplier) {
+            Ok(tokens) => Ok(tokens.try_into()?),
+            Err(_) => Err(StdError::generic_err("Token calculation overflow"))
+        };
     }
 
-    if let Some(tokens) = shares.checked_mul(t_tokens) {
-        return Ok((tokens / t_shares).as_u128());
-    } else {
-        return Err(StdError::generic_err("Token calculation overflow"));
-    }
+    return match shares.checked_mul(t_tokens) {
+        Ok(tokens) => Ok(tokens.checked_div(t_shares)?.try_into()?),
+        Err(_) => Err(StdError::generic_err("Token calculation overflow"))
+    };
 }
 
 ///
@@ -352,12 +350,12 @@ pub fn tokens_per_share(
 ///
 pub fn calculate_rewards(
     config: &StakeConfig,
-    tokens: u128,
-    shares: u128,
-    total_tokens: u128,
-    total_shares: u128,
-) -> StdResult<(u128, u128)> {
-    let token_reward = tokens_per_share(config, &shares, &total_tokens, &total_shares)? - tokens;
+    tokens: Uint128,
+    shares: Uint256,
+    total_tokens: Uint128,
+    total_shares: Uint256,
+) -> StdResult<(Uint128, Uint256)> {
+    let token_reward = tokens_per_share(config, &shares, &total_tokens, &total_shares)?.checked_sub(tokens.into())?;
     Ok((
         token_reward,
         shares_per_token(config, &token_reward, &total_tokens, &total_shares)?,
@@ -409,7 +407,7 @@ pub fn try_receive<S: Storage, A: Api, Q: Querier>(
                 &stake_config,
                 &target,
                 &target_canon,
-                amount.u128(),
+                amount,
             )?;
 
             // Store data
@@ -426,7 +424,7 @@ pub fn try_receive<S: Storage, A: Api, Q: Querier>(
             if let Some(treasury) = stake_config.treasury {
                 messages.push(send_msg(
                     treasury,
-                    amount,
+                    amount.into(),
                     None,
                     None,
                     None,
@@ -478,7 +476,7 @@ pub fn try_receive<S: Storage, A: Api, Q: Querier>(
             if remaining_amount > Uint128::zero() {
                 messages.push(send_msg(
                     sender,
-                    remaining_amount,
+                    remaining_amount.into(),
                     None,
                     None,
                     None,
@@ -491,7 +489,7 @@ pub fn try_receive<S: Storage, A: Api, Q: Querier>(
             store_fund_unbond(
                 &mut deps.storage,
                 &sender_canon,
-                (amount - remaining_amount)?,
+                amount.checked_sub(remaining_amount)?,
                 symbol,
                 None,
                 &env.block,
@@ -521,9 +519,9 @@ pub fn remove_from_cooldown<S: Storage>(
 
     cooldown.update(time);
 
-    let unlocked_tokens = (user_tokens - cooldown.total)?;
+    let unlocked_tokens = user_tokens.checked_sub(cooldown.total)?;
     if remove_amount > unlocked_tokens {
-        cooldown.remove_cooldown((remove_amount - unlocked_tokens)?);
+        cooldown.remove_cooldown(remove_amount.checked_sub(unlocked_tokens)?);
     }
     cooldown.save(store, user.as_str().as_bytes())?;
 
@@ -549,7 +547,7 @@ pub fn try_unbond<S: Storage, A: Api, Q: Querier>(
         &stake_config,
         &sender,
         &sender_canon,
-        amount.u128(),
+        amount,
         env.block.time,
     )?;
 
@@ -585,10 +583,10 @@ pub fn try_unbond<S: Storage, A: Api, Q: Querier>(
         .constants()?
         .symbol;
     let mut messages = vec![];
-    if claim != 0 {
+    if !claim.is_zero() {
         messages.push(send_msg(
             sender.clone(),
-            Uint128(claim),
+            claim.into(),
             None,
             None,
             None,
@@ -600,7 +598,7 @@ pub fn try_unbond<S: Storage, A: Api, Q: Querier>(
         store_claim_reward(
             &mut deps.storage,
             &sender_canon,
-            Uint128(claim),
+            claim,
             symbol.clone(),
             None,
             &env.block,
@@ -666,7 +664,7 @@ pub fn try_claim_unbond<S: Storage, A: Api, Q: Querier>(
     }
 
     unbond_queue.save(&mut deps.storage, sender.as_str().as_bytes())?;
-    total_unbonding.0 = (total_unbonding.0 - total)?;
+    total_unbonding.0 = total_unbonding.0.checked_sub(total)?;
     total_unbonding.save(&mut deps.storage)?;
 
     let symbol = ReadonlyConfig::from_storage(&deps.storage)
@@ -683,7 +681,7 @@ pub fn try_claim_unbond<S: Storage, A: Api, Q: Querier>(
 
     let messages = vec![send_msg(
         sender.clone(),
-        total,
+        total.into(),
         None,
         None,
         None,
@@ -710,13 +708,13 @@ pub fn try_claim_rewards<S: Storage, A: Api, Q: Querier>(
 
     let claim = claim_rewards(&mut deps.storage, &stake_config, sender, sender_canon)?;
 
-    if claim == 0 {
+    if claim.is_zero() {
         return Err(StdError::generic_err("Nothing to claim"));
     }
 
     let messages = vec![send_msg(
         sender.clone(),
-        Uint128(claim),
+        claim.into(),
         None,
         None,
         None,
@@ -731,7 +729,7 @@ pub fn try_claim_rewards<S: Storage, A: Api, Q: Querier>(
     store_claim_reward(
         &mut deps.storage,
         sender_canon,
-        Uint128(claim),
+        claim,
         symbol,
         None,
         &env.block,
@@ -757,12 +755,12 @@ pub fn try_stake_rewards<S: Storage, A: Api, Q: Querier>(
     let sender = &env.message.sender;
     let sender_canon = &deps.api.canonical_address(sender)?;
 
-    let claim = Uint128(claim_rewards(
+    let claim = claim_rewards(
         &mut deps.storage,
         &stake_config,
         sender,
         sender_canon,
-    )?);
+    )?;
 
     store_claim_reward(
         &mut deps.storage,
@@ -780,7 +778,7 @@ pub fn try_stake_rewards<S: Storage, A: Api, Q: Querier>(
         &stake_config,
         sender,
         sender_canon,
-        claim.u128(),
+        claim,
     )?;
 
     // Store data
@@ -800,7 +798,7 @@ pub fn try_stake_rewards<S: Storage, A: Api, Q: Querier>(
     if let Some(treasury) = stake_config.treasury {
         messages.push(send_msg(
             treasury,
-            claim,
+            claim.into(),
             None,
             None,
             None,
@@ -845,12 +843,12 @@ mod tests {
         let shares_decimals = 18;
         let config = init_config(token_decimals, shares_decimals);
 
-        let token_1 = 10000000 * 10u128.pow(token_decimals.into());
-        let share_1 = 10000000 * 10u128.pow(shares_decimals.into());
+        let token_1 = Uint128::new(10000000 * 10u128.pow(token_decimals.into()));
+        let share_1 = Uint256::from(10000000 * 10u128.pow(shares_decimals.into()));
 
         // Check for proper init
         assert_eq!(
-            tokens_per_share(&config, &share_1, &0, &0).unwrap(),
+            tokens_per_share(&config, &share_1, &Uint128::zero(), &Uint256::zero()).unwrap(),
             token_1
         );
 
@@ -860,15 +858,15 @@ mod tests {
             token_1
         );
         assert_eq!(
-            tokens_per_share(&config, &share_1, &(token_1 * 2), &(share_1 * 2)).unwrap(),
+            tokens_per_share(&config, &share_1, &(token_1 * Uint128::new(2)), &(share_1 * Uint256::from(2u32))).unwrap(),
             token_1
         );
 
         // check that shares increase when tokens decrease
-        assert!(tokens_per_share(&config, &share_1, &(token_1 * 2), &share_1).unwrap() > token_1);
+        assert!(tokens_per_share(&config, &share_1, &(token_1 * Uint128::new(2)), &share_1).unwrap() > token_1);
 
         // check that shares decrease when tokens increase
-        assert!(tokens_per_share(&config, &share_1, &token_1, &(share_1 * 2)).unwrap() < token_1);
+        assert!(tokens_per_share(&config, &share_1, &token_1, &(share_1 * Uint256::from(2u32))).unwrap() < token_1);
     }
 
     #[test]
@@ -877,12 +875,12 @@ mod tests {
         let shares_decimals = 18;
         let config = init_config(token_decimals, shares_decimals);
 
-        let token_1 = 100 * 10u128.pow(token_decimals.into());
-        let share_1 = 100 * 10u128.pow(shares_decimals.into());
+        let token_1 = Uint128::new(100 * 10u128.pow(token_decimals.into()));
+        let share_1 = Uint256::from(100 * 10u128.pow(shares_decimals.into()));
 
         // Check for proper init
         assert_eq!(
-            shares_per_token(&config, &token_1, &0, &0).unwrap(),
+            shares_per_token(&config, &token_1, &Uint128::zero(), &Uint256::zero()).unwrap(),
             share_1
         );
 
@@ -892,15 +890,15 @@ mod tests {
             share_1
         );
         assert_eq!(
-            shares_per_token(&config, &token_1, &(token_1 * 2), &(share_1 * 2)).unwrap(),
+            shares_per_token(&config, &token_1, &(token_1 * Uint128::new(2)), &(share_1 * Uint256::from(2u32))).unwrap(),
             share_1
         );
 
         // check that shares increase when tokens decrease
-        assert!(shares_per_token(&config, &token_1, &(token_1 * 2), &share_1).unwrap() < share_1);
+        assert!(shares_per_token(&config, &token_1, &(token_1 * Uint128::new(2)), &share_1).unwrap() < share_1);
 
         // check that shares decrease when tokens increase
-        assert!(shares_per_token(&config, &token_1, &token_1, &(share_1 * 2)).unwrap() > share_1);
+        assert!(shares_per_token(&config, &token_1, &token_1, &(share_1 * Uint256::from(2u32))).unwrap() > share_1);
     }
 
     #[test]
@@ -917,35 +915,35 @@ mod tests {
         // Tester has 100 tokens
         // Other user has 50
 
-        let u_t = 100 * 10u128.pow(token_decimals.into());
-        let mut u_s = 100 * 10u128.pow(shares_decimals.into());
-        let mut t_t = 150 * 10u128.pow(token_decimals.into());
-        let mut t_s = 150 * 10u128.pow(shares_decimals.into());
+        let u_t = Uint128::new(100 * 10u128.pow(token_decimals.into()));
+        let mut u_s = Uint256::from(100 * 10u128.pow(shares_decimals.into()));
+        let mut t_t = Uint128::new(150 * 10u128.pow(token_decimals.into()));
+        let mut t_s = Uint256::from(150 * 10u128.pow(shares_decimals.into()));
 
         // No rewards
         let (tokens, shares) = calculate_rewards(&config, u_t, u_s, t_t, t_s).unwrap();
 
-        assert_eq!(tokens, 0);
-        assert_eq!(shares, 0);
+        assert_eq!(tokens, Uint128::zero());
+        assert_eq!(shares, Uint256::zero());
 
         // Some rewards
         // We add 300 tokens, tester should get 200 tokens
         let reward = 300 * 10u128.pow(token_decimals.into());
-        t_t += reward;
+        t_t += Uint128::new(reward);
         let (tokens, shares) = calculate_rewards(&config, u_t, u_s, t_t, t_s).unwrap();
 
-        assert_eq!(tokens, reward * 2 / 3);
+        assert_eq!(tokens.u128(), reward * 2 / 3);
         t_t = t_t - tokens;
         // We should receive 2/3 of current shares
-        assert_eq!(shares, u_s * 2 / 3);
+        assert_eq!(shares, u_s * Uint256::from(2u32) / Uint256::from(3u32));
         u_s = u_s - shares;
         t_s = t_s - shares;
 
         // After claiming
         let (tokens, shares) = calculate_rewards(&config, u_t, u_s, t_t, t_s).unwrap();
 
-        assert_eq!(tokens, 0);
-        assert_eq!(shares, 0);
+        assert_eq!(tokens, Uint128::zero());
+        assert_eq!(shares, Uint256::zero());
     }
 
     #[test]
@@ -953,28 +951,28 @@ mod tests {
         let token_decimals = 8;
         let shares_decimals = 18;
         let config = init_config(token_decimals, shares_decimals);
-        let mut user_shares = Uint128::new(50000000000000);
+        let mut user_shares = Uint256::from(50000000000000u128);
 
-        let user_balance = 5000;
+        let user_balance = Uint128::new(5000);
 
         // Get total supplied tokens
-        let mut total_shares = Uint128::new(50000000000000);
+        let mut total_shares = Uint256::from(50000000000000u128);
         let mut total_tokens = Uint128::new(5000);
 
         let (reward_token, reward_shares) = calculate_rewards(
             &config,
             user_balance,
-            user_shares.u128(),
-            total_tokens.u128(),
-            total_shares.u128(),
+            user_shares,
+            total_tokens,
+            total_shares,
         )
         .unwrap();
 
-        assert_eq!(reward_token, 0);
+        assert_eq!(reward_token, Uint128::zero());
     }
 
     use rand::Rng;
-    use cosmwasm_math_compat::Uint128;
+    use cosmwasm_math_compat::{Uint128, Uint256};
 
     #[test]
     fn staking_simulation() {
@@ -982,8 +980,8 @@ mod tests {
         let shares_decimals = 18;
         let config = init_config(token_decimals, shares_decimals);
 
-        let mut t_t = 0;
-        let mut t_s = 0;
+        let mut t_t = Uint128::zero();
+        let mut t_s = Uint256::zero();
         let mut rand = rand::thread_rng();
 
         let mut stakers = vec![];
@@ -991,7 +989,7 @@ mod tests {
         for _ in 0..10 {
             // Generate stakers in this round
             for _ in 0..rand.gen_range(1..=4) {
-                let tokens = rand.gen_range(1..100 * 10u128.pow(token_decimals.into()));
+                let tokens = Uint128::new(rand.gen_range(1..100 * 10u128.pow(token_decimals.into())));
 
                 let shares = shares_per_token(&config, &tokens, &t_t, &t_s).unwrap();
 
@@ -1002,7 +1000,7 @@ mod tests {
             }
 
             // Add random rewards
-            t_t += rand.gen_range(1..t_t / 2);
+            t_t += Uint128::new(rand.gen_range(1u128..t_t.u128() / 2u128));
 
             // Claim and unstake
             for _ in 0..rand.gen_range(0..=stakers.len() / 2) {
@@ -1016,8 +1014,8 @@ mod tests {
 
                 let (r_tokens, r_shares) =
                     calculate_rewards(&config, tokens, shares, t_t, t_s).unwrap();
-                assert_eq!(r_tokens, 0);
-                assert_eq!(r_shares, 0);
+                assert_eq!(r_tokens, Uint128::zero());
+                assert_eq!(r_shares, Uint256::zero());
 
                 // Unstake
                 t_t -= tokens;
@@ -1036,8 +1034,8 @@ mod tests {
 
                 let (r_tokens, r_shares) =
                     calculate_rewards(&config, tokens, shares, t_t, t_s).unwrap();
-                assert_eq!(r_tokens, 0);
-                assert_eq!(r_shares, 0);
+                assert_eq!(r_tokens, Uint128::zero());
+                assert_eq!(r_shares, Uint256::zero());
             }
         }
     }

--- a/contracts/snip20_staking/src/state_staking.rs
+++ b/contracts/snip20_staking/src/state_staking.rs
@@ -1,13 +1,14 @@
-use cosmwasm_std::{HumanAddr, Uint128};
+use cosmwasm_std::{HumanAddr};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use cosmwasm_math_compat::{Uint128, Uint256};
 use shade_protocol::snip20_staking::stake::{Cooldown, DailyUnbonding, Unbonding, VecQueue};
 use shade_protocol::utils::storage::default::{BucketStorage, SingletonStorage};
 
 // used to determine what each token is worth to calculate rewards
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub struct TotalShares(pub Uint128);
+pub struct TotalShares(pub Uint256);
 
 impl SingletonStorage for TotalShares {
     const NAMESPACE: &'static [u8] = b"total_shares";
@@ -24,7 +25,7 @@ impl SingletonStorage for TotalTokens {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub struct UserShares(pub Uint128);
+pub struct UserShares(pub Uint256);
 
 impl BucketStorage for UserShares {
     const NAMESPACE: &'static [u8] = b"user_shares";
@@ -107,9 +108,9 @@ impl UserCooldown {
             let index = self.queue.0.len() - 1;
             if self.queue.0[index].amount <= remaining {
                 let item = self.queue.0.remove(index);
-                remaining = (remaining - item.amount).unwrap();
+                remaining = remaining.checked_sub(item.amount).unwrap();
             } else {
-                self.queue.0[index].amount = (self.queue.0[index].amount - remaining).unwrap();
+                self.queue.0[index].amount = self.queue.0[index].amount.checked_sub(remaining).unwrap();
                 break;
             }
         }
@@ -119,7 +120,7 @@ impl UserCooldown {
         while !self.queue.0.is_empty() {
             if self.queue.0[0].release <= time {
                 let i = self.queue.pop().unwrap();
-                self.total = (self.total - i.amount).unwrap();
+                self.total = self.total.checked_sub(i.amount).unwrap();
             } else {
                 break;
             }

--- a/contracts/snip20_staking/src/transaction_history.rs
+++ b/contracts/snip20_staking/src/transaction_history.rs
@@ -2,11 +2,12 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::{
-    Api, CanonicalAddr, Coin, HumanAddr, ReadonlyStorage, StdError, StdResult, Storage, Uint128,
+    Api, CanonicalAddr, Coin, HumanAddr, ReadonlyStorage, StdError, StdResult, Storage,
 };
 use cosmwasm_storage::{PrefixedStorage, ReadonlyPrefixedStorage};
 
 use secret_toolkit::storage::{AppendStore, AppendStoreMut};
+use cosmwasm_math_compat::Uint128;
 
 use crate::state::Config;
 
@@ -409,7 +410,7 @@ pub fn store_transfer<S: Storage>(
     block: &cosmwasm_std::BlockInfo,
 ) -> StdResult<()> {
     let id = increment_tx_count(store)?;
-    let coins = Coin { denom, amount };
+    let coins = Coin { denom, amount: amount.into() };
     let transfer = StoredLegacyTransfer {
         id,
         from: owner.clone(),
@@ -452,7 +453,7 @@ pub fn store_mint<S: Storage>(
     block: &cosmwasm_std::BlockInfo,
 ) -> StdResult<()> {
     let id = increment_tx_count(store)?;
-    let coins = Coin { denom, amount };
+    let coins = Coin { denom, amount: amount.into() };
     let action = StoredTxAction::mint(minter.clone(), recipient.clone());
     let tx = StoredRichTx::new(id, action, coins, memo, block);
 
@@ -474,7 +475,7 @@ pub fn store_burn<S: Storage>(
     block: &cosmwasm_std::BlockInfo,
 ) -> StdResult<()> {
     let id = increment_tx_count(store)?;
-    let coins = Coin { denom, amount };
+    let coins = Coin { denom, amount: amount.into() };
     let action = StoredTxAction::burn(owner.clone(), burner.clone());
     let tx = StoredRichTx::new(id, action, coins, memo, block);
 
@@ -495,7 +496,7 @@ pub fn store_stake<S: Storage>(
     block: &cosmwasm_std::BlockInfo,
 ) -> StdResult<()> {
     let id = increment_tx_count(store)?;
-    let coins = Coin { denom, amount };
+    let coins = Coin { denom, amount: amount.into() };
     let action = StoredTxAction::stake(staker.clone());
     let tx = StoredRichTx::new(id, action, coins, memo, block);
 
@@ -513,7 +514,7 @@ pub fn store_add_reward<S: Storage>(
     block: &cosmwasm_std::BlockInfo,
 ) -> StdResult<()> {
     let id = increment_tx_count(store)?;
-    let coins = Coin { denom, amount };
+    let coins = Coin { denom, amount: amount.into() };
     let action = StoredTxAction::add_reward(staker.clone());
     let tx = StoredRichTx::new(id, action, coins, memo, block);
 
@@ -531,7 +532,7 @@ pub fn store_fund_unbond<S: Storage>(
     block: &cosmwasm_std::BlockInfo,
 ) -> StdResult<()> {
     let id = increment_tx_count(store)?;
-    let coins = Coin { denom, amount };
+    let coins = Coin { denom, amount: amount.into() };
     let action = StoredTxAction::fund_unbond(staker.clone());
     let tx = StoredRichTx::new(id, action, coins, memo, block);
 
@@ -549,7 +550,7 @@ pub fn store_unbond<S: Storage>(
     block: &cosmwasm_std::BlockInfo,
 ) -> StdResult<()> {
     let id = increment_tx_count(store)?;
-    let coins = Coin { denom, amount };
+    let coins = Coin { denom, amount: amount.into() };
     let action = StoredTxAction::unbond(staker.clone());
     let tx = StoredRichTx::new(id, action, coins, memo, block);
 
@@ -567,7 +568,7 @@ pub fn store_claim_unbond<S: Storage>(
     block: &cosmwasm_std::BlockInfo,
 ) -> StdResult<()> {
     let id = increment_tx_count(store)?;
-    let coins = Coin { denom, amount };
+    let coins = Coin { denom, amount: amount.into() };
     let action = StoredTxAction::claim_unbond(staker.clone());
     let tx = StoredRichTx::new(id, action, coins, memo, block);
 
@@ -585,7 +586,7 @@ pub fn store_claim_reward<S: Storage>(
     block: &cosmwasm_std::BlockInfo,
 ) -> StdResult<()> {
     let id = increment_tx_count(store)?;
-    let coins = Coin { denom, amount };
+    let coins = Coin { denom, amount: amount.into() };
     let action = StoredTxAction::claim_reward(staker.clone());
     let tx = StoredRichTx::new(id, action, coins, memo, block);
 

--- a/packages/shade_protocol/src/snip20_staking/stake.rs
+++ b/packages/shade_protocol/src/snip20_staking/stake.rs
@@ -2,7 +2,8 @@ use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 use serde::{Deserialize, Serialize};
 use schemars::JsonSchema;
-use cosmwasm_std::{HumanAddr, Uint128};
+use cosmwasm_std::{HumanAddr};
+use cosmwasm_math_compat::Uint128;
 use crate::utils::storage::default::{BucketStorage, SingletonStorage};
 use crate::utils::asset::Contract;
 
@@ -50,10 +51,10 @@ impl DailyUnbonding {
             return amount
         }
 
-        let to_fund = (self.unbonding - self.funded).unwrap();
+        let to_fund = self.unbonding.checked_sub(self.funded).unwrap();
         if to_fund < amount {
             self.funded = self.unbonding.into();
-            return (amount - to_fund).unwrap()
+            return amount.checked_sub(to_fund).unwrap()
         }
 
         self.funded += amount;
@@ -148,29 +149,29 @@ mod tests {
 
     #[test]
     fn is_funded() {
-        assert!(DailyUnbonding{ unbonding: Uint128(100), funded: Uint128(100), release: 0 }.is_funded());
-        assert!(!DailyUnbonding{ unbonding: Uint128(150), funded: Uint128(100), release: 0 }.is_funded());
+        assert!(DailyUnbonding{ unbonding: Uint128::new(100), funded: Uint128::new(100), release: 0 }.is_funded());
+        assert!(!DailyUnbonding{ unbonding: Uint128::new(150), funded: Uint128::new(100), release: 0 }.is_funded());
     }
 
     #[test]
     fn fund() {
         // Initialize new unbond
-        let mut unbond = DailyUnbonding::new(Uint128(500), 0);
+        let mut unbond = DailyUnbonding::new(Uint128::new(500), 0);
         assert!(!unbond.is_funded());
 
         // Add small fund
-        let residue = unbond.fund(Uint128(250));
-        assert_eq!(unbond.funded, Uint128(250));
+        let residue = unbond.fund(Uint128::new(250));
+        assert_eq!(unbond.funded, Uint128::new(250));
         assert_eq!(residue, Uint128::zero());
 
         // Add overflowing fund
-        let residue = unbond.fund(Uint128(500));
+        let residue = unbond.fund(Uint128::new(500));
         assert!(unbond.is_funded());
-        assert_eq!(residue, Uint128(250));
+        assert_eq!(residue, Uint128::new(250));
 
         // Add to funded fund
-        let residue = unbond.fund(Uint128(300));
-        assert_eq!(residue, Uint128(300));
+        let residue = unbond.fund(Uint128::new(300));
+        assert_eq!(residue, Uint128::new(300));
     }
 
     #[test]
@@ -179,32 +180,32 @@ mod tests {
         assert_eq!(vec.0.len(), 0);
 
         vec.push(&QueueItem {
-            amount: Uint128(1),
+            amount: Uint128::new(1),
             release: 1
         });
         vec.push(&QueueItem {
-            amount: Uint128(1),
+            amount: Uint128::new(1),
             release: 2
         });
         vec.push(&QueueItem {
-            amount: Uint128(1),
+            amount: Uint128::new(1),
             release: 2
         });
         vec.push(&QueueItem {
-            amount: Uint128(1),
+            amount: Uint128::new(1),
             release: 3
         });
 
         assert_eq!(vec.0[0], QueueItem {
-            amount: Uint128(1),
+            amount: Uint128::new(1),
             release: 1
         });
         assert_eq!(vec.0[1], QueueItem {
-            amount: Uint128(2),
+            amount: Uint128::new(2),
             release: 2
         });
         assert_eq!(vec.0[2], QueueItem {
-            amount: Uint128(1),
+            amount: Uint128::new(1),
             release: 3
         });
     }

--- a/packages/shade_protocol/src/snip20_staking/stake.rs
+++ b/packages/shade_protocol/src/snip20_staking/stake.rs
@@ -144,7 +144,7 @@ pub trait VecQueueMerge {
 
 #[cfg(test)]
 mod tests {
-    use cosmwasm_std::Uint128;
+    use cosmwasm_math_compat::Uint128;
     use crate::snip20_staking::stake::{DailyUnbonding, QueueItem, VecQueue};
 
     #[test]


### PR DESCRIPTION
<!-- NOTE: Listed items are examples and should be removed when making a PR -->

# Description
Moved away from the `ethnum` library for 256bit unsigned integers and started using the compatibility uint library. By moving into the cosmwasm 1.0 uint lib staking now has most of its math in checked functions.

## Notable changes

<!-- List what the notable changes are -->

- Migration to the protocol uint library
- More type safety
- Shares storage is now natively `Uint256`

## Next steps

<!-- Following this PR what things need to be done -->

- Implement errors lib
- Push for 100% math safety
