### PR TITLE
Contract harness fix

### DIFF
--- a/packages/contract_harness/src/lib.rs
+++ b/packages/contract_harness/src/lib.rs
@@ -1,2 +1,4 @@
+#[cfg(not(target_arch = "wasm32"))]
 pub mod harness;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod harness_macro;


### PR DESCRIPTION
<!-- NOTE: Listed items are examples and should be removed when making a PR -->

# Description
Added two flags to prevent contract harness code from building when set to build in wasm32 architecture 

## Notable changes

<!-- List what the notable changes are -->

- Contract harness will not compile when targeting wasm32
