### PR TITLE
Better assert and fadroma commit lock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ members = [
 
   # Tools
   "tools/doc2book",
+
+  #"packages/network_integration"
 ]
 
 exclude = ["packages/network_integration"]

--- a/contracts/governance/Cargo.toml
+++ b/contracts/governance/Cargo.toml
@@ -45,6 +45,6 @@ shade-protocol = { version = "0.1.0", path = "../../packages/shade_protocol", fe
 serde_json = { version = "1.0.67" }
 mockall = "0.10.2"
 mockall_double = "0.2.0"
-fadroma = { branch = "v100", git = "https://github.com/hackbg/fadroma.git", features= ["ensemble"]  }
+fadroma = { branch = "v100", commit = 76867e0, git = "https://github.com/hackbg/fadroma.git", features= ["ensemble"]  }
 contract_harness = { version = "0.1.0", path = "../../packages/contract_harness", features = [ "governance", "snip20_staking", "snip20"  ] }
 spip_stkd_0 = { version = "0.1.0", path = "../snip20_staking" }

--- a/contracts/mint/Cargo.toml
+++ b/contracts/mint/Cargo.toml
@@ -38,7 +38,7 @@ snafu = { version = "0.6.3" }
 chrono = "0.4.19"
 
 [dev-dependencies]
-fadroma = { branch = "v100", git = "https://github.com/hackbg/fadroma.git", features = ["ensemble", "scrt"] }
+fadroma = { branch = "v100", commit = 76867e0, git = "https://github.com/hackbg/fadroma.git", features = ["ensemble", "scrt"] }
 contract_harness = { version = "0.1.0", path = "../../packages/contract_harness", features = ["mint", "snip20_reference_impl", "mock_band", "oracle"] }
 snip20-reference-impl = { version = "0.1.0", path = "../../contracts/snip20-reference-impl" }
 oracle = { version = "0.1.0", path = "../../contracts/oracle" }

--- a/contracts/oracle/Cargo.toml
+++ b/contracts/oracle/Cargo.toml
@@ -41,4 +41,4 @@ serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 snafu = { version = "0.6.3" }
 
 [dev-dependencies]
-fadroma = { branch = "v100", git = "https://github.com/hackbg/fadroma.git", features = ["ensemble"]}
+fadroma = { branch = "v100", commit = 76867e0, git = "https://github.com/hackbg/fadroma.git", features = ["ensemble"]}

--- a/contracts/query_auth/Cargo.toml
+++ b/contracts/query_auth/Cargo.toml
@@ -42,4 +42,4 @@ shade_admin = { git = "https://github.com/securesecrets/shadeadmin", tag = "v1.0
 contract_harness = { version = "0.1.0", path = "../../packages/contract_harness", features = [ "query_auth", "admin" ] }
 mockall = "0.10.2"
 mockall_double = "0.2.0"
-fadroma = { branch = "v100", git = "https://github.com/hackbg/fadroma.git", features= ["ensemble"] }
+fadroma = { branch = "v100", commit = 76867e0, git = "https://github.com/hackbg/fadroma.git", features= ["ensemble"] }

--- a/contracts/sky/Cargo.toml
+++ b/contracts/sky/Cargo.toml
@@ -33,7 +33,7 @@ cosmwasm-math-compat = { path = "../../packages/cosmwasm_math_compat" }
 shade-protocol = { version = "0.1.0", path = "../../packages/shade_protocol", features = ["sky", "sky-impl", "math"] }
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 schemars = "0.7"
-fadroma = { branch = "v100", git = "https://github.com/hackbg/fadroma.git" }
+fadroma = { branch = "v100", commit = 76867e0, git = "https://github.com/hackbg/fadroma.git" }
 
 [dev-dependencies]
 contract_harness = { version = "0.1.0", path = "../../packages/contract_harness" }

--- a/contracts/snip20/Cargo.toml
+++ b/contracts/snip20/Cargo.toml
@@ -44,4 +44,4 @@ snafu = { version = "0.6.3" }
 contract_harness = { version = "0.1.0", path = "../../packages/contract_harness", features = [ "snip20" ] }
 mockall = "0.10.2"
 mockall_double = "0.2.0"
-fadroma = { branch = "v100", git = "https://github.com/hackbg/fadroma.git", features= ["ensemble"] }
+fadroma = { branch = "v100", commit = 76867e0, git = "https://github.com/hackbg/fadroma.git", features= ["ensemble"] }

--- a/contracts/treasury/Cargo.toml
+++ b/contracts/treasury/Cargo.toml
@@ -39,7 +39,7 @@ chrono = "0.4.19"
 
 [dev-dependencies]
 contract_harness = { version = "0.1.0", path = "../../packages/contract_harness", features = ["treasury", "treasury_manager", "scrt_staking", "snip20_reference_impl" ] }
-fadroma = { branch = "v100", git = "https://github.com/hackbg/fadroma.git", features = ["ensemble", "scrt"] }
+fadroma = { branch = "v100", commit = 76867e0, git = "https://github.com/hackbg/fadroma.git", features = ["ensemble", "scrt"] }
 shade-protocol = { version = "0.1.0", path = "../../packages/shade_protocol", features = [
   "mint",
   "band",

--- a/contracts/treasury_manager/Cargo.toml
+++ b/contracts/treasury_manager/Cargo.toml
@@ -38,7 +38,7 @@ chrono = "0.4.19"
 
 [dev-dependencies]
 contract_harness = { version = "0.1.0", path = "../../packages/contract_harness" }
-fadroma = { branch = "v100", git = "https://github.com/hackbg/fadroma.git", features = ["ensemble", "scrt"] }
+fadroma = { branch = "v100", commit = 76867e0, git = "https://github.com/hackbg/fadroma.git", features = ["ensemble", "scrt"] }
 shade-protocol = { version = "0.1.0", path = "../../packages/shade_protocol", features = [
   "mint",
   "band",

--- a/packages/contract_harness/Cargo.toml
+++ b/packages/contract_harness/Cargo.toml
@@ -26,7 +26,7 @@ admin = ["dep:admin"]
 
 [dependencies]
 cosmwasm-std = { version = "0.10", package = "secret-cosmwasm-std" }
-fadroma = { branch = "v100", git = "https://github.com/hackbg/fadroma.git", features = [
+fadroma = { branch = "v100", commit = 76867e0, git = "https://github.com/hackbg/fadroma.git", features = [
   "ensemble",
 ] }
 mint = { version = "0.1.0", path = "../../contracts/mint", optional = true }

--- a/packages/contract_harness/src/lib.rs
+++ b/packages/contract_harness/src/lib.rs
@@ -1,4 +1,65 @@
+
+
 #[cfg(not(target_arch = "wasm32"))]
 pub mod harness;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod harness_macro;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub mod assertions {
+    use cosmwasm_std::{StdError, StdResult};
+    use fadroma::ensemble::ExecuteResponse;
+
+    use std::error::Error;
+    use std::panic::Location;
+
+    // New error type encapsulating the original error and location data.
+    #[derive(Debug, Clone)]
+    struct LocatedError<E: Error + 'static> {
+        inner: E,
+        location: &'static Location<'static>,
+    }
+
+    impl<E: Error + 'static> Error for LocatedError<E> {
+        fn source(&self) -> Option<&(dyn Error + 'static)> {
+            Some(&self.inner)
+        }
+    }
+
+    impl<E: Error + 'static> std::fmt::Display for LocatedError<E> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{}, {}", self.inner, self.location)
+        }
+    }
+
+    impl From<StdError> for LocatedError<StdError> {
+        #[track_caller]
+        fn from(err: StdError) -> Self {
+            LocatedError {
+                inner: err,
+                location: std::panic::Location::caller(),
+            }
+        }
+    }
+
+    fn locate_execute_error(
+        res: StdResult<ExecuteResponse>
+    ) -> Result<ExecuteResponse, LocatedError<StdError>> {
+        match res {
+            Ok(res) => Ok(res),
+            Err(err) => Err(LocatedError::from(err))
+        }
+    }
+
+    // Asserts that the execute is correct, if not it will print the error
+    pub fn assert_execute(res: StdResult<ExecuteResponse>) -> ExecuteResponse {
+        match locate_execute_error(res) {
+            Ok(res) => res,
+            Err(err) => {
+                assert!(false, "{}", err);
+                // Doing this so compiler will let this slide
+                panic!()
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- NOTE: Listed items are examples and should be removed when making a PR -->

# Description
<!-- Quick description of what this PR achieves -->

<!-- If it tackles any issue use something like - Fixes # (issue) -->

Locks fadroma packages to commit 76867e0 and added a function that neatly assers for an ensemble execute to be ok and if not it prints the errors source (its a better design than using `.is_ok()`)

## Notable changes

<!-- List what the notable changes are -->

- Fadroma commit lock
- Cleaner assersions

