### PR TITLE
Bumping uint from `=0.9.1` to `^0.9.3` for cw 1.0

### DIFF
--- a/packages/cosmwasm_math_compat/Cargo.toml
+++ b/packages/cosmwasm_math_compat/Cargo.toml
@@ -12,4 +12,4 @@ cosmwasm-std = { version = "0.10", package = "secret-cosmwasm-std" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 snafu = { version = "0.6.3" }
-uint = "=0.9.1"
+uint = "^0.9.3"


### PR DESCRIPTION
update
^ ugh