### PR TITLE
Added a way to reduce the annoyance of using newtypes with storage traits

### DIFF
--- a/packages/shade_protocol/src/contract_interfaces/snip20/helpers.rs
+++ b/packages/shade_protocol/src/contract_interfaces/snip20/helpers.rs
@@ -82,7 +82,7 @@ pub fn mint_msg(
     contract: &Contract
 ) -> StdResult<CosmosMsg> {
     ExecuteMsg::Mint {
-        recipient: recipient,
+        recipient,
         amount,
         memo,
         padding,

--- a/packages/shade_protocol/src/utils/crypto/mod.rs
+++ b/packages/shade_protocol/src/utils/crypto/mod.rs
@@ -1,6 +1,6 @@
 mod hash;
 mod rng;
-pub mod secp256k1;
+//pub mod secp256k1;
 
 pub use hash::{sha_256, SHA256_HASH_SIZE};
 pub use rng::Prng;

--- a/packages/shade_protocol/src/utils/storage/mod.rs
+++ b/packages/shade_protocol/src/utils/storage/mod.rs
@@ -1,5 +1,3 @@
-// TODO: replace with pub use
-
 #[cfg(feature = "storage_plus")]
 pub mod plus;
 


### PR DESCRIPTION
<!-- NOTE: Listed items are examples and should be removed when making a PR -->

# Description
<!-- Quick description of what this PR achieves -->

<!-- If it tackles any issue use something like - Fixes # (issue) -->

This addition aims to clean up how newtype storage is imagined

Originally, you would have this issue:
```
#[cw_serde]
pub struct NewType(pub u64);

impl ItemStorage for NewType {
    const ITEM: Item<'static, Self> = Item::new("newtype-");
}
```
Which would translate to using it like so
```
let mut t = NewType::load(deps.storage())?.0;
t = 200
NewType(t)::save(deps.storage())?;
```

This addition makes it so you can  change how the newtypes are seend, instead of being a storage wrapper for the item, it works like a boilerplate code generator
```
#[cw_serde]
pub struct NewType;

impl GenericItemStorage for NewType {
    const ITEM: Item<'static, u64> = Item::new("newtype-");
}
```
Which would translate to using it like so
```
let mut t = NewType::load(deps.storage())?;
t = 200
NewType::save(deps.storage(), t)?;
```
