### PR TITLE
Map and Item storage iterator

### DIFF
--- a/packages/shade_protocol/src/lib.rs
+++ b/packages/shade_protocol/src/lib.rs
@@ -14,12 +14,12 @@ pub mod storage {
     pub use cosmwasm_storage::*;
 }
 
-pub use schemars;
-pub use serde;
-pub use thiserror;
 pub use cosmwasm_schema;
+pub use schemars;
 #[cfg(feature = "storage_plus")]
 pub use secret_storage_plus;
+pub use serde;
+pub use thiserror;
 
 #[cfg(feature = "query_auth_lib")]
 pub use query_authentication;

--- a/packages/shade_protocol/src/utils/storage/plus/iter_item.rs
+++ b/packages/shade_protocol/src/utils/storage/plus/iter_item.rs
@@ -1,0 +1,210 @@
+use crate::utils::storage::plus::iter_map::{Increment, IndexableIterMap, IterMap};
+use cosmwasm_std::{to_binary, StdError, StdResult, Storage, Uint128};
+use secret_storage_plus::{Item, Json, Key, KeyDeserialize, Map, Prefixer, PrimaryKey, Serde};
+use serde::{
+    de::{self, DeserializeOwned},
+    ser,
+    Deserialize,
+    Serialize,
+};
+use std::{
+    marker::PhantomData,
+    ops::{Add, AddAssign, Index, Sub, SubAssign},
+};
+
+const KEY: &str = "ITER-ITEM-KEY-";
+
+pub struct IterItem<'a, T, N, Ser = Json>
+where
+    T: Serialize + DeserializeOwned,
+    N: Add<N, Output = N>
+        + AddAssign
+        + Increment
+        + Sub<N, Output = N>
+        + Serialize
+        + DeserializeOwned
+        + Clone,
+    Ser: Serde,
+{
+    iter_map: IterMap<'a, &'static str, T, N, Ser>,
+}
+
+impl<'a, T, N, Ser> IterItem<'a, T, N, Ser>
+where
+    T: Serialize + DeserializeOwned,
+    N: Add<N, Output = N>
+        + AddAssign
+        + Increment
+        + Sub<N, Output = N>
+        + Serialize
+        + DeserializeOwned
+        + Clone,
+    Ser: Serde,
+{
+    // TODO: gotta figure this out
+    // pub const fn new(namespace: &'a str) -> Self {
+    //     Self::new_override(namespace, PREFIX.as_bytes() + namespace.as_bytes())
+    // }
+
+    pub const fn new_override(namespace: &'a str, size_namespace: &'a str) -> Self {
+        IterItem {
+            iter_map: IterMap::new_override(namespace, size_namespace),
+        }
+    }
+}
+
+impl<'a, T, N, Ser> IterItem<'a, T, N, Ser>
+where
+    T: Serialize + DeserializeOwned,
+    N: Add<N, Output = N>
+        + AddAssign
+        + Increment
+        + Sub<N, Output = N>
+        + Serialize
+        + DeserializeOwned
+        + Clone,
+    Ser: Serde,
+{
+    pub fn set(&self, store: &mut dyn Storage, id: N, data: &T) -> StdResult<()> {
+        self.iter_map.set(store, KEY, id, data)
+    }
+
+    pub fn get(&self, store: &dyn Storage, id: N) -> StdResult<T> {
+        self.iter_map.get(store, KEY, id)
+    }
+
+    pub fn push(&self, store: &mut dyn Storage, data: &T) -> StdResult<N> {
+        self.iter_map.push(store, KEY, data)
+    }
+
+    pub fn remove(&self, store: &mut dyn Storage) -> StdResult<()> {
+        self.iter_map.remove(store, KEY)
+    }
+
+    pub fn size(&'a self, store: &dyn Storage) -> StdResult<N> {
+        self.iter_map.size(store, KEY)
+    }
+
+    pub fn iter_from(
+        &'a self,
+        store: &'a dyn Storage,
+        start_from: N,
+    ) -> IndexableIterMap<'a, &str, T, N, Ser> {
+        self.iter_map.iter_from(store, KEY, start_from)
+    }
+
+    pub fn iter(&'a self, store: &'a dyn Storage) -> IndexableIterMap<'a, &str, T, N, Ser> {
+        self.iter_map.iter(store, KEY)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::utils::storage::plus::iter_item::IterItem;
+    use cosmwasm_std::{
+        testing::{MockApi, MockQuerier, MockStorage},
+        Addr,
+        CustomQuery,
+        OwnedDeps,
+        Storage,
+        Uint64,
+    };
+    use serde::{
+        de::{self, DeserializeOwned},
+        ser,
+        Deserialize,
+        Serialize,
+    };
+    use std::marker::PhantomData;
+
+    #[derive(Clone, Serialize, Deserialize)]
+    struct MyQuery;
+    impl CustomQuery for MyQuery {}
+
+    #[test]
+    fn initialization() {
+        let mut storage = MockStorage::new();
+
+        let iter: IterItem<Uint64, u64> = IterItem::new_override("TEST", "SIZE-TEST");
+    }
+
+    fn generate(size: u8, storage: &mut dyn Storage) -> IterItem<Uint64, u64> {
+        let iter: IterItem<Uint64, u64> = IterItem::new_override("TEST", "SIZE-TEST");
+
+        for i in 0..size {
+            iter.push(storage, &Uint64::new(i as u64)).unwrap();
+        }
+
+        iter
+    }
+
+    #[test]
+    fn push() {
+        let mut storage = MockStorage::new();
+
+        generate(10, &mut storage);
+    }
+
+    #[test]
+    fn pop() {
+        let mut storage = MockStorage::new();
+
+        generate(10, &mut storage);
+    }
+
+    #[test]
+    fn set() {
+        let mut storage = MockStorage::new();
+
+        let iter: IterItem<Uint64, u64> = IterItem::new_override("TEST", "SIZE-TEST");
+
+        for i in 0..10 {
+            iter.push(&mut storage, &Uint64::new(i as u64)).unwrap();
+        }
+
+        iter.set(&mut storage, 3, &Uint64::new(5)).unwrap();
+
+        assert_eq!(Uint64::new(5), iter.get(&storage, 3).unwrap())
+    }
+
+    #[test]
+    fn get() {
+        let mut storage = MockStorage::new();
+
+        let iter: IterItem<Uint64, u64> = IterItem::new_override("TEST", "SIZE-TEST");
+
+        for i in 0..10 {
+            iter.push(&mut storage, &Uint64::new(i as u64)).unwrap();
+        }
+
+        assert_eq!(Uint64::new(3), iter.get(&storage, 3).unwrap())
+    }
+
+    #[test]
+    fn total() {
+        let mut storage = MockStorage::new();
+
+        let iter: IterItem<Uint64, u64> = IterItem::new_override("TEST", "SIZE-TEST");
+
+        for i in 0..10 {
+            iter.push(&mut storage, &Uint64::new(i as u64)).unwrap();
+        }
+
+        assert_eq!(10, iter.size(&storage).unwrap())
+    }
+
+    #[test]
+    fn iterate() {
+        let mut storage = MockStorage::new();
+
+        let iter: IterItem<String, Uint64, u64> = IterItem::new_override("TEST", "SIZE-TEST");
+
+        for i in 0..10 {
+            iter.push(&mut storage, &Uint64::new(i as u64)).unwrap();
+        }
+
+        for (i, item) in iter.iter(&storage).enumerate() {
+            assert_eq!(item, Uint64::new(i as u64))
+        }
+    }
+}

--- a/packages/shade_protocol/src/utils/storage/plus/iter_map.rs
+++ b/packages/shade_protocol/src/utils/storage/plus/iter_map.rs
@@ -1,0 +1,133 @@
+use cosmwasm_std::{StdError, StdResult, Storage, Uint128};
+use secret_storage_plus::{Item, Json, Key, KeyDeserialize, Map, Prefixer, PrimaryKey, Serde};
+use serde::{de::DeserializeOwned, Serialize};
+use std::{
+    marker::PhantomData,
+    ops::{Add, AddAssign, Index, Sub},
+};
+
+pub struct IterMap<'a, K, T, N, Ser = Json> {
+    storage: Map<'a, (K, N), T>,
+    id_storage: Item<'a, N>,
+    serialization_type: PhantomData<*const Ser>,
+}
+
+const PREFIX: &str = "iter-map-size-namespace-";
+
+impl<'a, K, T, N, Ser> IterMap<'a, K, T, N, Ser>
+where
+    T: Serialize + DeserializeOwned,
+    K: PrimaryKey<'a> + Prefixer<'a> + KeyDeserialize,
+    N: Serialize + DeserializeOwned + PrimaryKey<'a> + KeyDeserialize,
+    Ser: Serde,
+{
+    // TODO: gotta figure this out
+    // pub const fn new(namespace: &'a str) -> Self {
+    //     Self::new_override(namespace, PREFIX.as_bytes() + namespace.as_bytes())
+    // }
+
+    pub const fn new_override(namespace: &'a str, size_namespace: &'a str) -> Self {
+        IterMap {
+            storage: Map::new(namespace),
+            id_storage: Item::new(size_namespace),
+            serialization_type: PhantomData,
+        }
+    }
+}
+
+impl<'a, K, T, N, Ser> IterMap<'a, K, T, N, Ser>
+where
+    T: Serialize + DeserializeOwned,
+    K: PrimaryKey<'a> + Prefixer<'a> + KeyDeserialize,
+    N: Add<N, Output = N>
+        + Sub<N, Output = N>
+        + Serialize
+        + DeserializeOwned
+        + Into<u8>
+        + From<u8>
+        + PrimaryKey<'a>
+        + KeyDeserialize,
+    Ser: Serde,
+{
+    pub fn set(&self, store: &mut dyn Storage, key: K, id: N, data: &T) -> StdResult<()> {
+        self.storage.save(store, (key, id), data)
+    }
+
+    pub fn get(&self, store: &dyn Storage, key: K, id: N) -> StdResult<T> {
+        self.storage.load(store, (key, id))
+    }
+
+    pub fn push(&self, store: &mut dyn Storage, key: K, data: &T) -> StdResult<N> {
+        let id = match self.id_storage.may_load(store)? {
+            None => N::from(0),
+            Some(id) => id + N::from(1),
+        };
+
+        self.storage.save(store, (key, id.clone()), data)?;
+
+        self.id_storage.save(store, &id)?;
+
+        Ok(id)
+    }
+
+    pub fn remove(&self, store: &mut dyn Storage, key: K) -> StdResult<()> {
+        let id = match self.id_storage.may_load(store)? {
+            None => return Err(StdError::generic_err("Iter map is empty")),
+            Some(id) => id,
+        };
+
+        self.storage.remove(store, (key, id.clone()));
+
+        self.id_storage.save(store, &(id - N::from(1)))?;
+
+        Ok(())
+    }
+}
+
+// Make struct IterMapIndexable and implement the cool stuff there
+pub struct IndexableIterMap<'a, K, T, N, Ser> {
+    iter_map: IterMap<'a, K, T, N, Ser>,
+    storage: &'a dyn Storage,
+    key: K,
+    index: N,
+}
+
+impl<'a, K, T, N, Ser> IndexableIterMap<'a, K, T, N, Ser>
+where
+    N: Add<N, Output = N> + AddAssign + Into<u8> + From<u8> + PrimaryKey<'a> + KeyDeserialize,
+{
+    fn next_index(&mut self) {
+        self.index += N::from(1);
+    }
+}
+
+impl<'a, K, T, N, Ser> Iterator for IndexableIterMap<'a, K, T, N, Ser>
+where
+    T: Serialize + DeserializeOwned,
+    K: PrimaryKey<'a> + Prefixer<'a> + KeyDeserialize,
+    N: Add<N, Output = N>
+        + AddAssign
+        + Sub<N, Output = N>
+        + Serialize
+        + DeserializeOwned
+        + Into<u8>
+        + From<u8>
+        + PrimaryKey<'a>
+        + KeyDeserialize,
+    Ser: Serde,
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        let item = self
+            .iter_map
+            .get(self.storage.clone(), self.key.clone(), self.index.clone());
+
+        self.next_index();
+
+        match item {
+            Ok(i) => Some(i),
+            Err(_) => None,
+        }
+    }
+}

--- a/packages/shade_protocol/src/utils/storage/plus/iter_map.rs
+++ b/packages/shade_protocol/src/utils/storage/plus/iter_map.rs
@@ -1,14 +1,72 @@
-use cosmwasm_std::{StdError, StdResult, Storage, Uint128};
+use cosmwasm_std::{to_binary, StdError, StdResult, Storage, Uint128};
 use secret_storage_plus::{Item, Json, Key, KeyDeserialize, Map, Prefixer, PrimaryKey, Serde};
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{
+    de::{self, DeserializeOwned},
+    ser,
+    Deserialize,
+    Serialize,
+};
 use std::{
     marker::PhantomData,
-    ops::{Add, AddAssign, Index, Sub},
+    ops::{Add, AddAssign, Index, Sub, SubAssign},
 };
 
-pub struct IterMap<'a, K, T, N, Ser = Json> {
-    storage: Map<'a, (K, N), T>,
-    id_storage: Item<'a, N>,
+pub trait Increment {
+    fn one() -> Self;
+    fn zero() -> Self;
+}
+
+macro_rules! impl_increment {
+    ($($t:ty)*) => ($(
+        impl Increment for $t {
+            fn one() -> Self {
+                1
+            }
+
+            fn zero() -> Self {
+                0
+            }
+        }
+    )*)
+}
+
+impl_increment! { usize u8 u16 u32 u64 u128 }
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct IterKey<
+    N: Add<N, Output = N> + AddAssign + Sub<N, Output = N> + Clone + Serialize + Increment,
+> {
+    pub item: N,
+}
+
+impl<N> IterKey<N>
+where
+    N: Add<N, Output = N> + Increment + AddAssign + Sub<N, Output = N> + Clone + Serialize,
+{
+    pub fn new(item: N) -> Self {
+        Self { item }
+    }
+
+    pub fn to_bytes(&self) -> StdResult<Vec<u8>> {
+        Ok(to_binary(self)?.0)
+    }
+}
+
+pub struct IterMap<'a, K, T, N, Ser = Json>
+where
+    T: Serialize + DeserializeOwned,
+    K: PrimaryKey<'a> + Prefixer<'a> + KeyDeserialize,
+    N: Add<N, Output = N>
+        + AddAssign
+        + Increment
+        + Sub<N, Output = N>
+        + Serialize
+        + DeserializeOwned
+        + Clone,
+    Ser: Serde,
+{
+    storage: Map<'a, (K, Vec<u8>), T>,
+    id_storage: Map<'a, K, IterKey<N>>,
     serialization_type: PhantomData<*const Ser>,
 }
 
@@ -18,7 +76,13 @@ impl<'a, K, T, N, Ser> IterMap<'a, K, T, N, Ser>
 where
     T: Serialize + DeserializeOwned,
     K: PrimaryKey<'a> + Prefixer<'a> + KeyDeserialize,
-    N: Serialize + DeserializeOwned + PrimaryKey<'a> + KeyDeserialize,
+    N: Add<N, Output = N>
+        + AddAssign
+        + Increment
+        + Sub<N, Output = N>
+        + Serialize
+        + DeserializeOwned
+        + Clone,
     Ser: Serde,
 {
     // TODO: gotta figure this out
@@ -29,7 +93,7 @@ where
     pub const fn new_override(namespace: &'a str, size_namespace: &'a str) -> Self {
         IterMap {
             storage: Map::new(namespace),
-            id_storage: Item::new(size_namespace),
+            id_storage: Map::new(size_namespace),
             serialization_type: PhantomData,
         }
     }
@@ -40,53 +104,90 @@ where
     T: Serialize + DeserializeOwned,
     K: PrimaryKey<'a> + Prefixer<'a> + KeyDeserialize,
     N: Add<N, Output = N>
+        + AddAssign
+        + Increment
         + Sub<N, Output = N>
         + Serialize
         + DeserializeOwned
-        + Into<u8>
-        + From<u8>
-        + PrimaryKey<'a>
-        + KeyDeserialize,
+        + Clone,
     Ser: Serde,
 {
     pub fn set(&self, store: &mut dyn Storage, key: K, id: N, data: &T) -> StdResult<()> {
-        self.storage.save(store, (key, id), data)
+        self.storage
+            .save(store, (key, IterKey::new(id).to_bytes()?), data)
     }
 
     pub fn get(&self, store: &dyn Storage, key: K, id: N) -> StdResult<T> {
-        self.storage.load(store, (key, id))
+        self.storage
+            .load(store, (key, IterKey::new(id).to_bytes()?))
     }
 
     pub fn push(&self, store: &mut dyn Storage, key: K, data: &T) -> StdResult<N> {
-        let id = match self.id_storage.may_load(store)? {
-            None => N::from(0),
-            Some(id) => id + N::from(1),
-        };
+        let id = IterKey::new(match self.id_storage.may_load(store, key.clone())? {
+            None => N::zero(),
+            Some(id) => id.item + N::one(),
+        });
 
-        self.storage.save(store, (key, id.clone()), data)?;
+        self.storage
+            .save(store, (key.clone(), id.to_bytes()?), data)?;
 
-        self.id_storage.save(store, &id)?;
+        self.id_storage.save(store, key, &id)?;
 
-        Ok(id)
+        Ok(id.item)
     }
 
     pub fn remove(&self, store: &mut dyn Storage, key: K) -> StdResult<()> {
-        let id = match self.id_storage.may_load(store)? {
+        let id = match self.id_storage.may_load(store, key.clone())? {
             None => return Err(StdError::generic_err("Iter map is empty")),
             Some(id) => id,
         };
 
-        self.storage.remove(store, (key, id.clone()));
+        self.storage.remove(store, (key.clone(), id.to_bytes()?));
 
-        self.id_storage.save(store, &(id - N::from(1)))?;
+        let new_id = IterKey::new(id.item - N::one());
+        self.id_storage.save(store, key, &new_id)?;
 
         Ok(())
+    }
+
+    pub fn size(&'a self, store: &dyn Storage, key: K) -> StdResult<N> {
+        Ok(self.id_storage.load(store, key)?.item + N::one())
+    }
+
+    pub fn iter_from(
+        &'a self,
+        store: &'a dyn Storage,
+        key: K,
+        start_from: N,
+    ) -> IndexableIterMap<'a, K, T, N, Ser> {
+        IndexableIterMap {
+            iter_map: self,
+            storage: store,
+            key: key.clone(),
+            index: start_from,
+        }
+    }
+
+    pub fn iter(&'a self, store: &'a dyn Storage, key: K) -> IndexableIterMap<'a, K, T, N, Ser> {
+        self.iter_from(store, key, N::zero())
     }
 }
 
 // Make struct IterMapIndexable and implement the cool stuff there
-pub struct IndexableIterMap<'a, K, T, N, Ser> {
-    iter_map: IterMap<'a, K, T, N, Ser>,
+pub struct IndexableIterMap<'a, K, T, N, Ser>
+where
+    T: Serialize + DeserializeOwned,
+    K: PrimaryKey<'a> + Prefixer<'a> + KeyDeserialize,
+    N: Add<N, Output = N>
+        + AddAssign
+        + Increment
+        + Sub<N, Output = N>
+        + Serialize
+        + DeserializeOwned
+        + Clone,
+    Ser: Serde,
+{
+    iter_map: &'a IterMap<'a, K, T, N, Ser>,
     storage: &'a dyn Storage,
     key: K,
     index: N,
@@ -94,10 +195,19 @@ pub struct IndexableIterMap<'a, K, T, N, Ser> {
 
 impl<'a, K, T, N, Ser> IndexableIterMap<'a, K, T, N, Ser>
 where
-    N: Add<N, Output = N> + AddAssign + Into<u8> + From<u8> + PrimaryKey<'a> + KeyDeserialize,
+    T: Serialize + DeserializeOwned,
+    K: PrimaryKey<'a> + Prefixer<'a> + KeyDeserialize,
+    N: Add<N, Output = N>
+        + AddAssign
+        + Increment
+        + Sub<N, Output = N>
+        + Serialize
+        + DeserializeOwned
+        + Clone,
+    Ser: Serde,
 {
     fn next_index(&mut self) {
-        self.index += N::from(1);
+        self.index += N::one();
     }
 }
 
@@ -107,13 +217,11 @@ where
     K: PrimaryKey<'a> + Prefixer<'a> + KeyDeserialize,
     N: Add<N, Output = N>
         + AddAssign
+        + Increment
         + Sub<N, Output = N>
         + Serialize
         + DeserializeOwned
-        + Into<u8>
-        + From<u8>
-        + PrimaryKey<'a>
-        + KeyDeserialize,
+        + Clone,
     Ser: Serde,
 {
     type Item = T;
@@ -128,6 +236,129 @@ where
         match item {
             Ok(i) => Some(i),
             Err(_) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::utils::storage::plus::iter_map::IterMap;
+    use cosmwasm_std::{
+        testing::{MockApi, MockQuerier, MockStorage},
+        Addr,
+        CustomQuery,
+        OwnedDeps,
+        Storage,
+        Uint64,
+    };
+    use serde::{
+        de::{self, DeserializeOwned},
+        ser,
+        Deserialize,
+        Serialize,
+    };
+    use std::marker::PhantomData;
+
+    #[derive(Clone, Serialize, Deserialize)]
+    struct MyQuery;
+    impl CustomQuery for MyQuery {}
+
+    #[test]
+    fn initialization() {
+        let mut storage = MockStorage::new();
+
+        let iter: IterMap<(Addr), Uint64, u64> = IterMap::new_override("TEST", "SIZE-TEST");
+    }
+
+    fn generate(size: u8, storage: &mut dyn Storage) -> IterMap<(String), Uint64, u64> {
+        let iter: IterMap<(String), Uint64, u64> = IterMap::new_override("TEST", "SIZE-TEST");
+
+        for i in 0..size {
+            iter.push(storage, "TESTING".to_string(), &Uint64::new(i as u64))
+                .unwrap();
+        }
+
+        iter
+    }
+
+    #[test]
+    fn push() {
+        let mut storage = MockStorage::new();
+
+        generate(10, &mut storage);
+    }
+
+    #[test]
+    fn pop() {
+        let mut storage = MockStorage::new();
+
+        generate(10, &mut storage);
+    }
+
+    #[test]
+    fn set() {
+        let mut storage = MockStorage::new();
+
+        let iter: IterMap<String, Uint64, u64> = IterMap::new_override("TEST", "SIZE-TEST");
+
+        for i in 0..10 {
+            iter.push(&mut storage, "TESTING".to_string(), &Uint64::new(i as u64))
+                .unwrap();
+        }
+
+        iter.set(&mut storage, "TESTING".to_string(), 3, &Uint64::new(5))
+            .unwrap();
+
+        assert_eq!(
+            Uint64::new(5),
+            iter.get(&storage, "TESTING".to_string(), 3).unwrap()
+        )
+    }
+
+    #[test]
+    fn get() {
+        let mut storage = MockStorage::new();
+
+        let iter: IterMap<String, Uint64, u64> = IterMap::new_override("TEST", "SIZE-TEST");
+
+        for i in 0..10 {
+            iter.push(&mut storage, "TESTING".to_string(), &Uint64::new(i as u64))
+                .unwrap();
+        }
+
+        assert_eq!(
+            Uint64::new(3),
+            iter.get(&storage, "TESTING".to_string(), 3).unwrap()
+        )
+    }
+
+    #[test]
+    fn total() {
+        let mut storage = MockStorage::new();
+
+        let iter: IterMap<String, Uint64, u64> = IterMap::new_override("TEST", "SIZE-TEST");
+
+        for i in 0..10 {
+            iter.push(&mut storage, "TESTING".to_string(), &Uint64::new(i as u64))
+                .unwrap();
+        }
+
+        assert_eq!(10, iter.size(&storage, "TESTING".to_string()).unwrap())
+    }
+
+    #[test]
+    fn iterate() {
+        let mut storage = MockStorage::new();
+
+        let iter: IterMap<String, Uint64, u64> = IterMap::new_override("TEST", "SIZE-TEST");
+
+        for i in 0..10 {
+            iter.push(&mut storage, "TESTING".to_string(), &Uint64::new(i as u64))
+                .unwrap();
+        }
+
+        for (i, item) in iter.iter(&storage, "TESTING".to_string()).enumerate() {
+            assert_eq!(item, Uint64::new(i as u64))
         }
     }
 }

--- a/packages/shade_protocol/src/utils/storage/plus/iter_map.rs
+++ b/packages/shade_protocol/src/utils/storage/plus/iter_map.rs
@@ -136,7 +136,7 @@ where
         Ok(id.item)
     }
 
-    pub fn remove(&self, store: &mut dyn Storage, key: K) -> StdResult<()> {
+    pub fn pop(&self, store: &mut dyn Storage, key: K) -> StdResult<()> {
         let id = match self.id_storage.may_load(store, key.clone())? {
             None => return Err(StdError::generic_err("Iter map is empty")),
             Some(id) => id,
@@ -292,7 +292,16 @@ mod tests {
     fn pop() {
         let mut storage = MockStorage::new();
 
-        generate(10, &mut storage);
+        let iter: IterMap<String, Uint64, u64> = IterMap::new_override("TEST", "SIZE-TEST");
+
+        for i in 0..10 {
+            iter.push(&mut storage, "TESTING".to_string(), &Uint64::new(i as u64))
+                .unwrap();
+        }
+
+        iter.pop(&mut storage, "TESTING".to_string()).unwrap();
+
+        assert_eq!(9, iter.size(&storage, "TESTING".to_string()).unwrap());
     }
 
     #[test]

--- a/packages/shade_protocol/src/utils/storage/plus/iter_map.rs
+++ b/packages/shade_protocol/src/utils/storage/plus/iter_map.rs
@@ -173,7 +173,6 @@ where
     }
 }
 
-// Make struct IterMapIndexable and implement the cool stuff there
 pub struct IndexableIterMap<'a, K, T, N, Ser>
 where
     T: Serialize + DeserializeOwned,

--- a/packages/shade_protocol/src/utils/storage/plus/mod.rs
+++ b/packages/shade_protocol/src/utils/storage/plus/mod.rs
@@ -1,3 +1,4 @@
+//pub mod iter_item;
 pub mod iter_map;
 
 use crate::{

--- a/packages/shade_protocol/src/utils/storage/plus/mod.rs
+++ b/packages/shade_protocol/src/utils/storage/plus/mod.rs
@@ -1,10 +1,15 @@
-use crate::c_std::{StdError, StdResult, Storage};
-use crate::serde::{de::DeserializeOwned, Serialize};
+pub mod iter_map;
 
-pub use secret_storage_plus::{Item, Map, PrimaryKey, Json, Bincode2, Serde};
+use crate::{
+    c_std::{StdError, StdResult, Storage},
+    serde::{de::DeserializeOwned, Serialize},
+};
 
-pub trait NaiveItemStorage<Ser = Json>: Serialize + DeserializeOwned 
-    where Ser: Serde
+pub use secret_storage_plus::{Bincode2, Item, Json, Map, PrimaryKey, Serde};
+
+pub trait NaiveItemStorage<Ser = Json>: Serialize + DeserializeOwned
+where
+    Ser: Serde,
 {
     fn load(storage: &dyn Storage, item: Item<Self, Ser>) -> StdResult<Self> {
         item.load(storage)
@@ -22,18 +27,24 @@ pub trait NaiveItemStorage<Ser = Json>: Serialize + DeserializeOwned
         item.save(storage, self)
     }
 
-    fn update<A, E>(&self, storage: &mut dyn Storage, item: Item<Self, Ser>, action: A) -> Result<Self, E>
-        where
-            A: FnOnce(Self) -> Result<Self, E>,
-            E: From<StdError>,
+    fn update<A, E>(
+        &self,
+        storage: &mut dyn Storage,
+        item: Item<Self, Ser>,
+        action: A,
+    ) -> Result<Self, E>
+    where
+        A: FnOnce(Self) -> Result<Self, E>,
+        E: From<StdError>,
     {
         item.update(storage, action)
     }
 }
 
 pub trait ItemStorage<Ser = Json>: Serialize + DeserializeOwned
-where Ser: Serde
- {
+where
+    Ser: Serde,
+{
     const ITEM: Item<'static, Self, Ser>;
 
     fn load(storage: &dyn Storage) -> StdResult<Self> {
@@ -61,8 +72,10 @@ where Ser: Serde
     }
 }
 
-pub trait GenericItemStorage<T : Serialize + DeserializeOwned, Ser = Json> 
-where Ser: Serde {
+pub trait GenericItemStorage<T: Serialize + DeserializeOwned, Ser = Json>
+where
+    Ser: Serde,
+{
     const ITEM: Item<'static, T, Ser>;
 
     fn load(storage: &dyn Storage) -> StdResult<T> {
@@ -78,21 +91,31 @@ where Ser: Serde {
     }
 
     fn update<A, E, S: Storage>(storage: &mut dyn Storage, action: A) -> Result<T, E>
-        where
-            A: FnOnce(T) -> Result<T, E>,
-            E: From<StdError>,
+    where
+        A: FnOnce(T) -> Result<T, E>,
+        E: From<StdError>,
     {
         Self::ITEM.update(storage, action)
     }
 }
 
 pub trait NaiveMapStorage<'a, Ser = Json>: Serialize + DeserializeOwned
-where Ser: Serde {
-    fn load<K: PrimaryKey<'a>>(storage: &dyn Storage, map: Map<'a, K, Self, Ser>, key: K) -> StdResult<Self> {
+where
+    Ser: Serde,
+{
+    fn load<K: PrimaryKey<'a>>(
+        storage: &dyn Storage,
+        map: Map<'a, K, Self, Ser>,
+        key: K,
+    ) -> StdResult<Self> {
         map.load(storage, key)
     }
 
-    fn may_load<K: PrimaryKey<'a>>(storage: &dyn Storage, map: Map<'a, K, Self, Ser>, key: K) -> StdResult<Option<Self>> {
+    fn may_load<K: PrimaryKey<'a>>(
+        storage: &dyn Storage,
+        map: Map<'a, K, Self, Ser>,
+        key: K,
+    ) -> StdResult<Option<Self>> {
         map.may_load(storage, key)
     }
 
@@ -100,21 +123,34 @@ where Ser: Serde {
         map.remove(storage, key)
     }
 
-    fn save<K: PrimaryKey<'a>>(&self, storage: &mut dyn Storage, map: Map<'a, K, Self, Ser>, key: K) -> StdResult<()> {
+    fn save<K: PrimaryKey<'a>>(
+        &self,
+        storage: &mut dyn Storage,
+        map: Map<'a, K, Self, Ser>,
+        key: K,
+    ) -> StdResult<()> {
         map.save(storage, key, self)
     }
 
-    fn update<A, E, K: PrimaryKey<'a>>(&self, storage: &mut dyn Storage, map: Map<'a, K, Self, Ser>, key: K, action: A) -> Result<Self, E>
-        where
-            A: FnOnce(Option<Self>) -> Result<Self, E>,
-            E: From<StdError>,
+    fn update<A, E, K: PrimaryKey<'a>>(
+        &self,
+        storage: &mut dyn Storage,
+        map: Map<'a, K, Self, Ser>,
+        key: K,
+        action: A,
+    ) -> Result<Self, E>
+    where
+        A: FnOnce(Option<Self>) -> Result<Self, E>,
+        E: From<StdError>,
     {
         map.update(storage, key, action)
     }
 }
 
 pub trait MapStorage<'a, K: PrimaryKey<'a>, Ser = Json>: Serialize + DeserializeOwned
-where Ser: Serde {
+where
+    Ser: Serde,
+{
     const MAP: Map<'static, K, Self, Ser>;
 
     fn load(storage: &dyn Storage, key: K) -> StdResult<Self> {
@@ -142,8 +178,10 @@ where Ser: Serde {
     }
 }
 
-pub trait GenericMapStorage<'a, K: PrimaryKey<'a>, T: Serialize + DeserializeOwned, Ser = Json> 
-where Ser: Serde{
+pub trait GenericMapStorage<'a, K: PrimaryKey<'a>, T: Serialize + DeserializeOwned, Ser = Json>
+where
+    Ser: Serde,
+{
     const MAP: Map<'static, K, T, Ser>;
 
     fn load(storage: &dyn Storage, key: K) -> StdResult<T> {
@@ -159,9 +197,9 @@ where Ser: Serde{
     }
 
     fn update<A, E, S: Storage>(&self, storage: &mut dyn Storage, key: K, action: A) -> Result<T, E>
-        where
-            A: FnOnce(Option<T>) -> Result<T, E>,
-            E: From<StdError>,
+    where
+        A: FnOnce(Option<T>) -> Result<T, E>,
+        E: From<StdError>,
     {
         Self::MAP.update(storage, key, action)
     }

--- a/packages/shade_protocol/src/utils/storage/plus/mod.rs
+++ b/packages/shade_protocol/src/utils/storage/plus/mod.rs
@@ -1,4 +1,4 @@
-//pub mod iter_item;
+pub mod iter_item;
 pub mod iter_map;
 
 use crate::{


### PR DESCRIPTION
<!-- NOTE: Listed items are examples and should be removed when making a PR -->

# Description
<!-- Quick description of what this PR achieves -->

<!-- If it tackles any issue use something like - Fixes # (issue) -->

Taking into consideration the cosmwasm limitations, Item and Map now have equivalents for iteration

## Notable changes

<!-- List what the notable changes are -->

- Added an Item equivalent that lets you iterate the members like if it was an array
- Added a Map equivalent that does the same as the IterItem

## Next steps

<!-- Following this PR what things need to be done -->

- The `::new()` function isnt working because I need to build a string at compile time, still need to find a solution for this
