### PR TITLE
Period storage

### DIFF
--- a/packages/shade_protocol/src/utils/cycle.rs
+++ b/packages/shade_protocol/src/utils/cycle.rs
@@ -21,6 +21,23 @@ pub enum Cycle {
     Seconds { seconds: Uint128 },
 }
 
+#[cw_serde]
+pub enum Period {
+    Once,
+    Constant,
+    /*
+    Block {
+        blocks: Uint128,
+    },
+    */
+    Yearly { years: Uint128 },
+    Monthly { months: Uint128 },
+    Daily { days: Uint128 },
+    Hourly { hours: Uint128 },
+    Minutes { minutes: Uint128 },
+    Seconds { seconds: Uint128 },
+}
+
 pub fn utc_from_seconds(seconds: i64) -> DateTime<Utc> {
     DateTime::from_utc(NaiveDateTime::from_timestamp(seconds, 0), Utc)
 }

--- a/packages/shade_protocol/src/utils/mod.rs
+++ b/packages/shade_protocol/src/utils/mod.rs
@@ -25,6 +25,7 @@ pub mod storage;
 
 #[cfg(feature = "dao-utils")]
 pub mod cycle;
+
 #[cfg(feature = "dao-utils")]
 pub mod wrap;
 

--- a/packages/shade_protocol/src/utils/storage/plus/iter_map.rs
+++ b/packages/shade_protocol/src/utils/storage/plus/iter_map.rs
@@ -2,7 +2,9 @@ use cosmwasm_std::{to_binary, StdError, StdResult, Storage, Uint128};
 use secret_storage_plus::{Item, Json, Key, KeyDeserialize, Map, Prefixer, PrimaryKey, Serde};
 use serde::{
     de::{self, DeserializeOwned},
-    ser, Deserialize, Serialize,
+    ser,
+    Deserialize,
+    Serialize,
 };
 use std::{
     marker::PhantomData,
@@ -242,11 +244,17 @@ mod tests {
     use crate::utils::storage::plus::iter_map::IterMap;
     use cosmwasm_std::{
         testing::{MockApi, MockQuerier, MockStorage},
-        Addr, CustomQuery, OwnedDeps, Storage, Uint64,
+        Addr,
+        CustomQuery,
+        OwnedDeps,
+        Storage,
+        Uint64,
     };
     use serde::{
         de::{self, DeserializeOwned},
-        ser, Deserialize, Serialize,
+        ser,
+        Deserialize,
+        Serialize,
     };
     use std::marker::PhantomData;
 

--- a/packages/shade_protocol/src/utils/storage/plus/mod.rs
+++ b/packages/shade_protocol/src/utils/storage/plus/mod.rs
@@ -1,5 +1,6 @@
 pub mod iter_item;
 pub mod iter_map;
+pub mod period_storage;
 
 use crate::{
     c_std::{StdError, StdResult, Storage},

--- a/packages/shade_protocol/src/utils/storage/plus/period_storage.rs
+++ b/packages/shade_protocol/src/utils/storage/plus/period_storage.rs
@@ -1,0 +1,119 @@
+use crate::{
+    c_std::{StdError, StdResult, Storage, Timestamp},
+    serde::{de::DeserializeOwned, Serialize},
+    utils::cycle::*,
+};
+use chrono::prelude::*;
+pub use secret_storage_plus::{Item, Json, Map, PrimaryKey, Serde};
+
+use super::iter_item::IterItem;
+
+pub enum Period {
+    Hour,
+    Day,
+    Month,
+}
+
+pub fn map_key(seconds: u64, period: Period) -> String {
+    let datetime = utc_from_seconds(seconds as i64);
+    match period {
+        Period::Hour => datetime.format("%Y-%m-%dT%h").to_string(),
+        Period::Day => datetime.format("%Y-%m-%d").to_string(),
+        Period::Month => datetime.format("%Y-%m").to_string(),
+    }
+}
+
+pub struct PeriodStorage<'a, T, Ser = Json>
+where
+    T: Serialize + DeserializeOwned,
+    Ser: Serde,
+{
+    all: Map<'a, u64, Vec<T>, Ser>,
+    recent: Item<'a, Vec<u64>>,
+
+    /* keys are date formatted strings "%Y-%m-%dT%h"
+     * right-most data is truncated to categorize by higher order
+     * e.g. month format is "%Y-%m"
+     */
+    hour: Map<'a, String, Vec<T>, Ser>,
+    day: Map<'a, String, Vec<T>, Ser>,
+    month: Map<'a, String, Vec<T>, Ser>,
+}
+
+impl<'a, T, Ser> PeriodStorage<'a, T, Ser>
+where
+    T: Serialize + DeserializeOwned,
+    Ser: Serde,
+{
+    fn load(&self, storage: &dyn Storage, ts: Timestamp) -> StdResult<Vec<T>> {
+        self.all.load(storage, ts.seconds())
+    }
+
+    fn load_period(
+        &self,
+        storage: &dyn Storage,
+        ts: Timestamp,
+        period: Period,
+    ) -> StdResult<Vec<T>> {
+        match period {
+            Period::Hour => self.hour.load(storage, map_key(ts.seconds(), period)),
+            Period::Day => self.day.load(storage, map_key(ts.seconds(), period)),
+            Period::Month => self.month.load(storage, map_key(ts.seconds(), period)),
+        }
+    }
+
+    fn may_load(&self, storage: &dyn Storage, ts: Timestamp) -> StdResult<Vec<T>> {
+        Ok(self.all.may_load(storage, ts.seconds())?.unwrap_or(vec![]))
+    }
+
+    fn push(&self, storage: &mut dyn Storage, ts: Timestamp, item: T) -> StdResult<()> {
+        let key = ts.seconds();
+        let mut recent = self.recent.may_load(storage)?.unwrap_or(vec![]);
+        if !recent.contains(&key) {
+            recent.push(key);
+            self.recent.save(storage, &recent)?;
+        }
+        let mut all = self.all.may_load(storage, key)?.unwrap_or(vec![]);
+        all.push(item);
+        self.all.save(storage, key, &all)
+    }
+
+    fn append(
+        &self,
+        storage: &mut dyn Storage,
+        ts: Timestamp,
+        items: &mut Vec<T>,
+    ) -> StdResult<()> {
+        let key = ts.seconds();
+        let mut recent = self.recent.may_load(storage)?.unwrap_or(vec![]);
+        if !recent.contains(&key) {
+            recent.push(key);
+            self.recent.save(storage, &recent)?;
+        }
+        let mut all = self.all.may_load(storage, key)?.unwrap_or(vec![]);
+        all.append(items);
+        self.all.save(storage, key, &all)
+    }
+
+    fn flush(&self, storage: &mut dyn Storage) -> StdResult<()> {
+        for seconds in self.recent.load(storage)? {
+            let mut items = self.all.load(storage, seconds)?;
+
+            let k = map_key(seconds, Period::Hour);
+            let mut cur_items = self.hour.load(storage, k.clone())?;
+            cur_items.append(&mut items);
+            self.hour.save(storage, k, &cur_items)?;
+
+            let k = map_key(seconds, Period::Day);
+            let mut cur_items = self.day.load(storage, k.clone())?;
+            cur_items.append(&mut items);
+            self.day.save(storage, k, &cur_items)?;
+
+            let k = map_key(seconds, Period::Month);
+            let mut cur_items = self.month.load(storage, k.clone())?;
+            cur_items.append(&mut items);
+            self.month.save(storage, k, &cur_items)?;
+        }
+        self.recent.save(storage, &vec![])
+    }
+}

--- a/packages/shade_protocol/src/utils/storage/plus/period_storage.rs
+++ b/packages/shade_protocol/src/utils/storage/plus/period_storage.rs
@@ -95,6 +95,9 @@ where
         self.all.save(storage, key, &all)
     }
 
+    /* This will move all "recents" into the time based storage
+     * This should likely be called at the end of execution that adds items
+     */
     fn flush(&self, storage: &mut dyn Storage) -> StdResult<()> {
         for seconds in self.recent.load(storage)? {
             let mut items = self.all.load(storage, seconds)?;


### PR DESCRIPTION
Storage type to organize data by an associated datetime.

The chosen type `T` will be used to store in various `Map<Timestamp, Vec<T>>` storages.
`all` is a `{ seconds: Vec<T> }`
`recent` is a list of `[ seconds, ...]` to correlate to `all` in order to pull "unflushed" elements
When `flush` is called, it will iterate `recent` and organize into dated storages, with formatted datetime strings as keys

Keys:
`hour`: `%Y-%m-%dT%h`
`day`: `%Y-%m-%d`
`month`: `%Y-%m`

The basic use case I have so far is for "metrics" (currently implemented in `treasury`). This allows all storage to be queryable based on a datetime from the client, allowing for smaller bits of targeted data depending on what the front-end needs.

Added pagination can be performed by the client (may be useful to add in this object) as the biggest risk I can see is that the `month` storage becomes too big to be queryable (the main reason I removed "year" storage)

It may be useful to add higher resolution storages such as "second" & "minute", if these are added I think it would be good to make it configurable to a low & high resolution range or something similar.