### PR TITLE
Query auth/versioning

### DIFF
--- a/contracts/query_auth/src/query.rs
+++ b/contracts/query_auth/src/query.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Api, Extern, HumanAddr, Querier, StdResult, Storage};
+use cosmwasm_std::{Api, Extern, HumanAddr, Querier, StdError, StdResult, Storage};
 use shade_protocol::{
     contract_interfaces::query_auth::{
         auth::{Key, PermitKey},
@@ -9,6 +9,7 @@ use shade_protocol::{
     },
     utils::storage::plus::{ItemStorage, MapStorage},
 };
+use shade_protocol::contract_interfaces::query_auth::VERSION;
 
 pub fn config<S: Storage, A: Api, Q: Querier>(deps: &Extern<S, A, Q>) -> StdResult<QueryAnswer> {
     Ok(QueryAnswer::Config {
@@ -32,6 +33,9 @@ pub fn validate_permit<S: Storage, A: Api, Q: Querier>(
     permit: QueryPermit,
 ) -> StdResult<QueryAnswer> {
     let user = permit.validate(&deps.api, None)?.as_humanaddr(None)?;
+    if permit.params.ver != VERSION {
+        return Err(StdError::unauthorized())
+    }
 
     Ok(QueryAnswer::ValidatePermit {
         user: user.clone(),

--- a/contracts/query_auth/src/tests/mod.rs
+++ b/contracts/query_auth/src/tests/mod.rs
@@ -62,7 +62,8 @@ pub fn get_permit() -> QueryPermit {
     QueryPermit {
         params: PermitData {
             key: "key".to_string(),
-            data: Binary::from_base64("c29tZSBzdHJpbmc=").unwrap()
+            data: Binary::from_base64("c29tZSBzdHJpbmc=").unwrap(),
+            ver: 1
         },
         signature: PermitSignature {
             pub_key: PubKey::new(

--- a/contracts/query_auth/src/tests/query.rs
+++ b/contracts/query_auth/src/tests/query.rs
@@ -1,7 +1,7 @@
 use crate::{
     tests::{get_permit, init_contract},
 };
-use cosmwasm_std::{testing::*, HumanAddr};
+use cosmwasm_std::{testing::*, HumanAddr, StdResult};
 use fadroma::ensemble::MockEnv;
 use shade_protocol::contract_interfaces::{
     query_auth,
@@ -92,7 +92,7 @@ fn validate_vk() {
 
 #[test]
 fn validate_permit() {
-    let permit = get_permit();
+    let mut permit = get_permit();
 
     let deps = mock_dependencies(20, &[]);
 
@@ -102,8 +102,8 @@ fn validate_permit() {
     let (chain, auth) = init_contract().unwrap();
 
     let query: query_auth::QueryAnswer = chain
-        .query(auth.address, &query_auth::QueryMsg::ValidatePermit {
-            permit,
+        .query(auth.address.clone(), &query_auth::QueryMsg::ValidatePermit {
+            permit: permit.clone(),
         })
         .unwrap();
 
@@ -117,4 +117,13 @@ fn validate_permit() {
         }
         _ => assert!(false),
     };
+
+    permit.params.ver = 2;
+
+    let query: StdResult<query_auth::QueryAnswer> = chain
+        .query(auth.address, &query_auth::QueryMsg::ValidatePermit {
+            permit: permit,
+        });
+
+    assert!(query.is_err());
 }

--- a/packages/shade_protocol/src/contract_interfaces/query_auth/mod.rs
+++ b/packages/shade_protocol/src/contract_interfaces/query_auth/mod.rs
@@ -14,6 +14,8 @@ use secret_storage_plus::Item;
 use secret_toolkit::crypto::sha_256;
 use crate::utils::asset::Contract;
 
+pub const VERSION: u8 = 1;
+
 #[cfg(feature = "query_auth_impl")]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -125,6 +127,7 @@ pub type QueryPermit = Permit<PermitData>;
 pub struct PermitData {
     pub data: Binary,
     pub key: String,
+    pub ver: u8,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]


### PR DESCRIPTION
Add versioning to supported queries so that old permit formats and exploited permits can be mass revoked.