### PR TITLE
Treasury wrap

### DIFF
--- a/contracts/treasury/src/contract.rs
+++ b/contracts/treasury/src/contract.rs
@@ -66,6 +66,10 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> S
             let mut contract = contract.into_valid(deps.api)?;
             execute::register_manager(deps, &env, info, &mut contract)
         }
+        ExecuteMsg::RegisterWrap { denom, contract } => {
+            let contract = contract.into_valid(deps.api)?;
+            execute::register_wrap(deps, &env, info, denom, &contract)
+        }
         ExecuteMsg::Allowance { asset, allowance } => {
             let asset = deps.api.addr_validate(&asset)?;
             execute::allowance(deps, &env, info, asset, allowance)
@@ -77,6 +81,7 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> S
         ExecuteMsg::SetRunLevel { run_level } => {
             execute::set_run_level(deps, &env, info, run_level)
         }
+        ExecuteMsg::WrapCoins {} => execute::wrap_coins(deps, &env, info),
     }
 }
 

--- a/contracts/treasury/src/execute.rs
+++ b/contracts/treasury/src/execute.rs
@@ -689,10 +689,15 @@ pub fn register_wrap(
         &config.admin_auth,
     )?;
 
-    if ASSET
-        .may_load(deps.storage, contract.address.clone())?
-        .is_none()
-    {
+    if let Some(a) = ASSET.may_load(deps.storage, contract.address.clone())? {
+        if let Some(conf) = a.token_config {
+            if !conf.deposit_enabled {
+                return Err(StdError::generic_err("Asset must have deposit enabled"));
+            }
+        } else {
+            return Err(StdError::generic_err("Asset has no config"));
+        }
+    } else {
         return Err(StdError::generic_err("Unrecognized Asset"));
     }
 

--- a/contracts/treasury/src/execute.rs
+++ b/contracts/treasury/src/execute.rs
@@ -5,12 +5,14 @@ use shade_protocol::{
         Addr,
         Api,
         Binary,
+        Coin,
         CosmosMsg,
         Deps,
         DepsMut,
         Env,
         MessageInfo,
         Querier,
+        QuerierWrapper,
         Response,
         StdError,
         StdResult,
@@ -48,6 +50,7 @@ use shade_protocol::{
         asset::Contract,
         cycle::{exceeds_cycle, parse_utc_datetime, utc_from_seconds, utc_now},
         generic_response::ResponseStatus,
+        wrap::wrap_coin,
     },
 };
 
@@ -670,6 +673,38 @@ pub fn try_register_asset(
         })?))
 }
 
+pub fn register_wrap(
+    deps: DepsMut,
+    env: &Env,
+    info: MessageInfo,
+    denom: String,
+    contract: &Contract,
+) -> StdResult<Response> {
+    let config = CONFIG.load(deps.storage)?;
+
+    validate_admin(
+        &deps.querier,
+        AdminPermissions::TreasuryAdmin,
+        &info.sender,
+        &config.admin_auth,
+    )?;
+
+    if ASSET
+        .may_load(deps.storage, contract.address.clone())?
+        .is_none()
+    {
+        return Err(StdError::generic_err("Unrecognized Asset"));
+    }
+
+    WRAP.save(deps.storage, denom, &contract.address)?;
+
+    Ok(
+        Response::new().set_data(to_binary(&ExecuteAnswer::RegisterWrap {
+            status: ResponseStatus::Success,
+        })?),
+    )
+}
+
 pub fn register_manager(
     deps: DepsMut,
     _env: &Env,
@@ -765,4 +800,25 @@ pub fn allowance(
             status: ResponseStatus::Success,
         })?),
     )
+}
+
+pub fn wrap_coins(deps: DepsMut, env: &Env, info: MessageInfo) -> StdResult<Response> {
+    let coins = deps.querier.query_all_balances(&env.contract.address)?;
+    let mut messages = vec![];
+    let mut success = vec![];
+    let mut failed = vec![];
+
+    for coin in coins {
+        if let Some(asset) = WRAP.may_load(deps.storage, coin.denom.clone())? {
+            let token = ASSET.load(deps.storage, asset)?;
+            messages.push(wrap_coin(coin.clone(), token.contract)?);
+            success.push(coin);
+        } else {
+            failed.push(coin);
+        }
+    }
+
+    Ok(Response::new()
+        .add_messages(messages)
+        .set_data(to_binary(&ExecuteAnswer::WrapCoins { success, failed })?))
 }

--- a/contracts/treasury/src/storage.rs
+++ b/contracts/treasury/src/storage.rs
@@ -9,8 +9,6 @@ use shade_protocol::{
     },
 };
 
-use chrono::*;
-
 pub const CONFIG: Item<Config> = Item::new("config");
 pub const VIEWING_KEY: Item<String> = Item::new("viewing_key");
 pub const SELF_ADDRESS: Item<Addr> = Item::new("self_address");
@@ -18,16 +16,13 @@ pub const SELF_ADDRESS: Item<Addr> = Item::new("self_address");
 pub const ASSET_LIST: IterItem<Addr, u64> = IterItem::new_override("asset_list", "asset_list_2");
 pub const ASSET: Map<Addr, Snip20Asset> = Map::new("asset");
 
+// { denom: snip20 }
+pub const WRAP: Map<String, Addr> = Map::new("wrap");
+
 pub const MANAGER: Map<Addr, Contract> = Map::new("managers");
 pub const ALLOWANCES: Map<Addr, Vec<AllowanceMeta>> = Map::new("allowances");
 
 pub const RUN_LEVEL: Item<RunLevel> = Item::new("runlevel");
-
-/*
-pub fn metric_key(datetime: DateTime<Utc>) -> String {
-    datetime.format("%Y-%m-%d").to_string()
-}
-*/
 
 pub const METRICS: PeriodStorage<Metric> =
     PeriodStorage::new("metrics-all", "metrics-recent", "metrics-timed");

--- a/contracts/treasury/tests/wrap_integration.rs
+++ b/contracts/treasury/tests/wrap_integration.rs
@@ -1,0 +1,174 @@
+use mock_adapter;
+use shade_multi_test::{
+    interfaces,
+    multi::{
+        admin::init_admin_auth,
+        mock_adapter::MockAdapter,
+        snip20::Snip20,
+        treasury::Treasury,
+        treasury_manager::TreasuryManager,
+    },
+};
+use shade_protocol::{
+    c_std::{
+        coins,
+        from_binary,
+        to_binary,
+        Addr,
+        Binary,
+        Coin,
+        ContractInfo,
+        Decimal,
+        Env,
+        StdError,
+        StdResult,
+        Uint128,
+        Validator,
+    },
+    multi_test::{App, BankSudo, StakingSudo, SudoMsg},
+};
+use shade_protocol::{
+    contract_interfaces::{
+        dao::{
+            adapter,
+            manager,
+            //mock_adapter,
+            treasury,
+            treasury::{Allowance, AllowanceType, RunLevel},
+            treasury_manager::{self, Allocation, AllocationType},
+        },
+        snip20,
+    },
+    utils::{
+        asset::{Contract, RawContract},
+        cycle::{utc_from_timestamp, Cycle},
+        storage::plus::period_storage::Period,
+        ExecuteCallback,
+        InstantiateCallback,
+        MultiTestable,
+        Query,
+    },
+};
+
+use serde_json;
+
+// Add other adapters here as they come
+fn wrap_coins_test(coins: Vec<Coin>) {
+    let mut app = App::default();
+
+    let admin = Addr::unchecked("admin");
+    let user = Addr::unchecked("user");
+    //let validator = Addr::unchecked("validator");
+    let admin_auth = init_admin_auth(&mut app, &admin);
+
+    let viewing_key = "viewing_key".to_string();
+
+    let mut tokens = vec![];
+
+    for coin in coins.clone() {
+        let token = snip20::InstantiateMsg {
+            name: coin.denom.clone(),
+            admin: Some("admin".into()),
+            symbol: coin.denom.to_uppercase().clone(),
+            decimals: 6,
+            initial_balances: None,
+            prng_seed: to_binary("").ok().unwrap(),
+            config: Some(snip20::InitConfig {
+                public_total_supply: Some(true),
+                enable_deposit: Some(true),
+                enable_redeem: Some(true),
+                enable_mint: Some(false),
+                enable_burn: Some(false),
+                enable_transfer: Some(true),
+            }),
+            query_auth: None,
+        }
+        .test_init(Snip20::default(), &mut app, admin.clone(), &coin.denom, &[])
+        .unwrap();
+
+        tokens.push(token);
+    }
+
+    let treasury = treasury::InstantiateMsg {
+        admin_auth: admin_auth.clone().into(),
+        viewing_key: viewing_key.clone(),
+        multisig: admin.to_string().clone(),
+    }
+    .test_init(Treasury::default(), &mut app, admin.clone(), "treasury", &[
+    ])
+    .unwrap();
+
+    /*
+    // Set admin viewing key
+    snip20::ExecuteMsg::SetViewingKey {
+        key: viewing_key.clone(),
+        padding: None,
+    }
+    .test_exec(&token, &mut app, admin.clone(), &[])
+    .unwrap();
+    */
+
+    // Register treasury assets
+    for (token, coin) in tokens.iter().zip(coins.clone().iter()) {
+        treasury::ExecuteMsg::RegisterAsset {
+            contract: token.clone().into(),
+        }
+        .test_exec(&treasury, &mut app, admin.clone(), &[])
+        .unwrap();
+
+        treasury::ExecuteMsg::RegisterWrap {
+            denom: coin.denom.clone(),
+            contract: RawContract {
+                address: token.address.clone().into(),
+                code_hash: token.code_hash.clone(),
+            },
+        }
+        .test_exec(&treasury, &mut app, admin.clone(), &[])
+        .unwrap();
+    }
+
+    app.init_modules(|router, _, storage| {
+        router
+            .bank
+            .init_balance(storage, &treasury.address.clone(), coins.clone())
+            .unwrap();
+    });
+
+    // Wrap
+    treasury::ExecuteMsg::WrapCoins {}
+        .test_exec(&treasury, &mut app, admin.clone(), &[])
+        .unwrap();
+
+    // Treasury Balances
+    for (token, coin) in tokens.iter().zip(coins.iter()) {
+        match (treasury::QueryMsg::Balance {
+            asset: token.address.to_string().clone(),
+        }
+        .test_query(&treasury, &app)
+        .unwrap())
+        {
+            treasury::QueryAnswer::Balance { amount } => {
+                assert_eq!(amount, coin.amount, "Treasury Balance");
+            }
+            _ => panic!("Query Failed"),
+        };
+    }
+}
+
+macro_rules! wrap_coins_tests {
+    ($($name:ident: $value:expr,)*) => {
+        $(
+            #[test]
+            fn $name() {
+                let coins = $value;
+                wrap_coins_test(coins);
+            }
+        )*
+    }
+}
+
+wrap_coins_tests! {
+    wrap_sscrt: (
+        vec![Coin { denom: "uscrt".into(), amount: Uint128::new(100) }]
+    ),
+}

--- a/contracts/treasury/tests/wrap_integration.rs
+++ b/contracts/treasury/tests/wrap_integration.rs
@@ -168,7 +168,6 @@ macro_rules! wrap_coins_tests {
 }
 
 wrap_coins_tests! {
-    wrap_sscrt: (
-        vec![Coin { denom: "uscrt".into(), amount: Uint128::new(100) }]
-    ),
+    wrap_sscrt: vec![Coin { denom: "uscrt".into(), amount: Uint128::new(100) }],
+    //wrap_other: vec![Coin { denom: "other".into(), amount: Uint128::new(100) }],
 }

--- a/contracts/treasury_manager/src/execute.rs
+++ b/contracts/treasury_manager/src/execute.rs
@@ -48,7 +48,7 @@ use crate::storage::*;
 
 pub fn receive(
     deps: DepsMut,
-    _env: Env,
+    env: Env,
     info: MessageInfo,
     _sender: Addr,
     from: Addr,
@@ -109,7 +109,7 @@ pub fn receive(
 
 pub fn try_update_config(
     deps: DepsMut,
-    _env: Env,
+    env: Env,
     info: MessageInfo,
     config: Config,
 ) -> StdResult<Response> {
@@ -173,7 +173,7 @@ pub fn try_register_asset(
 
 pub fn allocate(
     deps: DepsMut,
-    _env: &Env,
+    env: &Env,
     info: MessageInfo,
     asset: Addr,
     allocation: Allocation,
@@ -771,7 +771,7 @@ pub fn update(deps: DepsMut, env: &Env, _info: MessageInfo, asset: Addr) -> StdR
 
 pub fn unbond(
     deps: DepsMut,
-    _env: &Env,
+    env: &Env,
     info: MessageInfo,
     asset: Addr,
     amount: Uint128,
@@ -1301,7 +1301,7 @@ pub fn add_holder(
 
 pub fn remove_holder(
     deps: DepsMut,
-    _env: &Env,
+    env: &Env,
     info: MessageInfo,
     holder: Addr,
 ) -> StdResult<Response> {

--- a/packages/shade_protocol/src/contract_interfaces/dao/treasury.rs
+++ b/packages/shade_protocol/src/contract_interfaces/dao/treasury.rs
@@ -5,7 +5,7 @@ use crate::utils::{
 };
 
 use crate::{
-    c_std::{Addr, Binary, StdResult, Uint128},
+    c_std::{Addr, Binary, Coin, StdResult, Uint128},
     contract_interfaces::dao::adapter,
 };
 
@@ -113,6 +113,11 @@ pub enum ExecuteMsg {
     RegisterManager {
         contract: RawContract,
     },
+    RegisterWrap {
+        denom: String,
+        contract: RawContract,
+    },
+    WrapCoins {},
     // Setup a new allowance
     Allowance {
         asset: String,
@@ -145,6 +150,9 @@ pub enum ExecuteAnswer {
     RegisterAsset {
         status: ResponseStatus,
     },
+    RegisterWrap {
+        status: ResponseStatus,
+    },
     Allowance {
         status: ResponseStatus,
     },
@@ -162,6 +170,10 @@ pub enum ExecuteAnswer {
     },
     RunLevel {
         run_level: RunLevel,
+    },
+    WrapCoins {
+        success: Vec<Coin>,
+        failed: Vec<Coin>,
     },
 }
 

--- a/packages/shade_protocol/src/utils/wrap.rs
+++ b/packages/shade_protocol/src/utils/wrap.rs
@@ -1,56 +1,34 @@
 use cosmwasm_std::SubMsg;
 
-use crate::utils::{asset::Contract};
-use crate::c_std::{
-    Binary,
-    CosmosMsg,
-    Addr,
-    StdResult,
-    Uint128,
+use crate::{
+    c_std::{Addr, Binary, Coin, CosmosMsg, StdResult, Uint128},
+    snip20::{
+        self,
+        helpers::{deposit_msg, redeem_msg, send_msg},
+    },
+    utils::{asset::Contract, ExecuteCallback},
 };
-use crate::snip20::helpers::{deposit_msg, redeem_msg, send_msg};
 
-pub fn wrap(
-    amount: Uint128,
-    token: Contract,
-    //denom: Option<String>,
-) -> StdResult<CosmosMsg> {
-    Ok(deposit_msg(
-        amount,
-        None,
-        &token
-    )?)
+pub fn wrap(amount: Uint128, token: Contract) -> StdResult<CosmosMsg> {
+    Ok(deposit_msg(amount, None, &token)?)
+}
+
+pub fn wrap_coin(coin: Coin, token: Contract) -> StdResult<CosmosMsg> {
+    snip20::ExecuteMsg::Deposit { padding: None }.to_cosmos_msg(&token, vec![coin])
 }
 
 pub fn wrap_and_send(
     amount: Uint128,
     recipient: Addr,
     token: Contract,
-    //denom: Option<String>,
     msg: Option<Binary>,
 ) -> StdResult<Vec<CosmosMsg>> {
     Ok(vec![
         wrap(amount, token.clone())?,
-        send_msg(
-            recipient,
-            amount,
-            msg,
-            None,
-            None,
-            &token
-        )?,
+        send_msg(recipient, amount, msg, None, None, &token)?,
     ])
 }
 
-pub fn unwrap(
-    amount: Uint128,
-    token: Contract,
-    //denom: Option<String>,
-) -> StdResult<CosmosMsg> {
-    Ok(redeem_msg(
-        amount,
-        None,
-        None,
-        &token
-    )?)
+pub fn unwrap(amount: Uint128, token: Contract) -> StdResult<CosmosMsg> {
+    Ok(redeem_msg(amount, None, None, &token)?)
 }


### PR DESCRIPTION
Treasury can now `WrapCoins {}` to wrap all its L1 coins that have a configured wrap token, configured with `RegisterWrap { denom, contract }`

Tested with `uscrt` as well as a `fail` denom that it cannot successfully wrap.

Need to import `snip20-reference-impl` on the branch `ibc` and rework test to allow any number of denoms configured in tests