### PR TITLE
Symbol -> Name for oracle queries

### DIFF
--- a/contracts/bonds/src/handle.rs
+++ b/contracts/bonds/src/handle.rs
@@ -780,7 +780,7 @@ pub fn amount_to_issue<S: Storage, A: Api, Q: Querier>(
     err_issued_price: Uint128,
 ) -> StdResult<(Uint128, Uint128, Uint128, Uint128)> {
     let mut disc = discount;
-    let mut deposit_price = oracle(deps, deposit_asset.token_info.symbol.clone())?;
+    let mut deposit_price = oracle(deps, deposit_asset.token_info.name.clone())?;
     if deposit_price > max_accepted_deposit_price {
         if deposit_price > err_deposit_price {
             return Err(deposit_price_exceeds_limit(
@@ -790,7 +790,7 @@ pub fn amount_to_issue<S: Storage, A: Api, Q: Querier>(
         }
         deposit_price = max_accepted_deposit_price;
     }
-    let mut issued_price = oracle(deps, issuance_asset.token_info.symbol.clone())?;
+    let mut issued_price = oracle(deps, issuance_asset.token_info.name.clone())?;
     if issued_price < err_issued_price {
         return Err(issued_price_below_minimum(
             issued_price,

--- a/contracts/bonds/src/tests/mod.rs
+++ b/contracts/bonds/src/tests/mod.rs
@@ -311,6 +311,30 @@ pub fn init_contracts() -> StdResult<(
         .execute(&msg, MockEnv::new("admin", router.clone()))
         .is_ok());
 
+    let msg = router::HandleMsg::UpdateRegistry { 
+        operation: router::RegistryOperation::UpdateAlias { alias: "Deposit".to_string(), key: "DEPO".to_string() } 
+    };
+
+    assert!(chain
+        .execute(&msg, MockEnv::new("admin", router.clone()))
+        .is_ok());
+
+    let msg = router::HandleMsg::UpdateRegistry { 
+        operation: router::RegistryOperation::UpdateAlias { alias: "Issued".to_string(), key: "ISSU".to_string() } 
+    };
+    
+    assert!(chain
+        .execute(&msg, MockEnv::new("admin", router.clone()))
+        .is_ok());
+    
+    let msg = router::HandleMsg::UpdateRegistry { 
+        operation: router::RegistryOperation::UpdateAlias { alias: "Atom".to_string(), key: "ATOM".to_string() } 
+    };
+
+    assert!(chain
+        .execute(&msg, MockEnv::new("admin", router.clone()))
+        .is_ok());
+
     // Register query_auth
     let query_auth = chain.register(Box::new(QueryAuth));
     let query_auth = chain


### PR DESCRIPTION
Signed-off-by: Kyle Wahlberg <kyle.s.wahlberg@gmail.com>

Updated oracle query to use snip20 names, rather than symbols. Test updated to reflect this change by using aliases.
