### PR TITLE
Iter storage constant string fix

### DIFF
--- a/packages/shade_protocol/src/utils/storage/plus/iter_item.rs
+++ b/packages/shade_protocol/src/utils/storage/plus/iter_item.rs
@@ -19,7 +19,15 @@ where
     id_storage: Item<'a, IterKey<N>>,
 }
 
-// const PREFIX: &str = "iter-map-size-namespace-";
+#[macro_export]
+macro_rules! new_iter_item {
+    ($StoragePath:tt) => {
+        IterItem::new_override(
+            $StoragePath,
+            concat!("iter-item-size-namespace-", $StoragePath),
+        )
+    };
+}
 
 impl<'a, T, N> IterItem<'a, T, N>
 where
@@ -32,11 +40,6 @@ where
         + DeserializeOwned
         + Clone,
 {
-    // TODO: gotta figure this out
-    // pub const fn new(namespace: &'a str) -> Self {
-    //     Self::new_override(namespace, PREFIX.as_bytes() + namespace.as_bytes())
-    // }
-
     pub const fn new_override(namespace: &'a str, size_namespace: &'a str) -> Self {
         IterItem {
             storage: Map::new(namespace),
@@ -210,6 +213,8 @@ mod tests {
     #[derive(Clone, Serialize, Deserialize)]
     struct MyQuery;
     impl CustomQuery for MyQuery {}
+
+    const MACRO_TEST: IterItem<Uint64, u64> = new_iter_item!("MACRO_TEST");
 
     #[test]
     fn initialization() {

--- a/packages/shade_protocol/src/utils/storage/plus/iter_map.rs
+++ b/packages/shade_protocol/src/utils/storage/plus/iter_map.rs
@@ -60,7 +60,15 @@ where
     id_storage: Map<'a, K, IterKey<N>>,
 }
 
-// const PREFIX: &str = "iter-map-size-namespace-";
+#[macro_export]
+macro_rules! new_iter_map {
+    ($StoragePath:tt) => {
+        IterMap::new_override(
+            $StoragePath,
+            concat!("iter-map-size-namespace-", $StoragePath),
+        )
+    };
+}
 
 impl<'a, K, T, N> IterMap<'a, K, T, N>
 where
@@ -74,11 +82,6 @@ where
         + DeserializeOwned
         + Clone,
 {
-    // TODO: gotta figure this out
-    // pub const fn new(namespace: &'a str) -> Self {
-    //     Self::new_override(namespace, PREFIX.as_bytes() + namespace.as_bytes())
-    // }
-
     pub const fn new_override(namespace: &'a str, size_namespace: &'a str) -> Self {
         IterMap {
             storage: Map::new(namespace),
@@ -263,6 +266,8 @@ mod tests {
     #[derive(Clone, Serialize, Deserialize)]
     struct MyQuery;
     impl CustomQuery for MyQuery {}
+
+    const MACRO_TEST: IterMap<(Addr), Uint64, u64> = new_iter_map!("MACRO_TEST");
 
     #[test]
     fn initialization() {


### PR DESCRIPTION
<!-- NOTE: Listed items are examples and should be removed when making a PR -->

# Description
<!-- Quick description of what this PR achieves -->

<!-- If it tackles any issue use something like - Fixes # (issue) -->

"Fixed" the issue with not being able to concatenate strings on the constant function.

## Notable changes

<!-- List what the notable changes are -->

- Iter storage now has a macro wrapper to get by the concatenation limits when handling variables.