### PR TITLE
schema generator

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -63,7 +63,7 @@ rm ./${CURRENT_CRATE}.wasm
 [tasks.schemas]
 workspace = false
 script = '''
-cargo run --bin schemas --features="admin airdrop bonds dao dex governance-impl mint oracles peg_stability query_auth sky snip20 staking"
+cargo run --bin schemas --features="admin airdrop bonds dao dex governance-impl mint oracles peg_stability query_auth sky snip20 staking mint_router"
 '''
 
 # Testing

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -60,6 +60,12 @@ cat ./${CURRENT_CRATE}.wasm | gzip -n -9 > ${COMPILED_DIR}/${CURRENT_CRATE}.wasm
 rm ./${CURRENT_CRATE}.wasm
 '''
 
+[tasks.schemas]
+workspace = false
+script = '''
+cargo run --bin schemas --features="admin airdrop bonds dao dex governance-impl mint oracles peg_stability query_auth sky snip20 staking"
+'''
+
 # Testing
 
 [tasks.test]

--- a/contracts/airdrop/src/handle.rs
+++ b/contracts/airdrop/src/handle.rs
@@ -57,7 +57,7 @@ use shade_protocol::{
             unexpected_error,
         },
         Config,
-        HandleAnswer,
+        ExecuteAnswer,
     },
     query_authentication::viewing_keys::ViewingKey,
     snip20::helpers::send_msg,
@@ -173,7 +173,7 @@ pub fn try_update_config(
 
         Ok(state)
     })?;
-    Ok(Response::new().set_data(to_binary(&HandleAnswer::UpdateConfig { status: Success })?))
+    Ok(Response::new().set_data(to_binary(&ExecuteAnswer::UpdateConfig { status: Success })?))
 }
 
 pub fn try_add_tasks(
@@ -205,7 +205,7 @@ pub fn try_add_tasks(
         Ok(config)
     })?;
 
-    Ok(Response::new().set_data(to_binary(&HandleAnswer::AddTask { status: Success })?))
+    Ok(Response::new().set_data(to_binary(&ExecuteAnswer::AddTask { status: Success })?))
 }
 
 pub fn try_account(
@@ -332,7 +332,7 @@ pub fn try_account(
     // Save account
     account_w(deps.storage).save(sender.as_bytes(), &account)?;
 
-    Ok(Response::new().set_data(to_binary(&HandleAnswer::Account {
+    Ok(Response::new().set_data(to_binary(&ExecuteAnswer::Account {
         status: ResponseStatus::Success,
         total: account.total_claimable,
         claimed: account_total_claimed_r(deps.storage).load(sender.to_string().as_bytes())?,
@@ -351,7 +351,7 @@ pub fn try_disable_permit_key(
     revoke_permit(deps.storage, info.sender.to_string(), key);
 
     Ok(
-        Response::new().set_data(to_binary(&HandleAnswer::DisablePermitKey {
+        Response::new().set_data(to_binary(&ExecuteAnswer::DisablePermitKey {
             status: Success,
         })?),
     )
@@ -366,7 +366,11 @@ pub fn try_set_viewing_key(
     account_viewkey_w(deps.storage)
         .save(&info.sender.to_string().as_bytes(), &AccountKey(key).hash())?;
 
-    Ok(Response::new().set_data(to_binary(&HandleAnswer::SetViewingKey { status: Success })?))
+    Ok(
+        Response::new().set_data(to_binary(&ExecuteAnswer::SetViewingKey {
+            status: Success,
+        })?),
+    )
 }
 
 pub fn try_complete_task(
@@ -393,7 +397,7 @@ pub fn try_complete_task(
         }
     }
 
-    Ok(Response::new().set_data(to_binary(&HandleAnswer::CompleteTask { status: Success })?))
+    Ok(Response::new().set_data(to_binary(&ExecuteAnswer::CompleteTask { status: Success })?))
 }
 
 pub fn try_claim(deps: DepsMut, env: &Env, info: &MessageInfo) -> StdResult<Response> {
@@ -428,7 +432,7 @@ pub fn try_claim(deps: DepsMut, env: &Env, info: &MessageInfo) -> StdResult<Resp
         .update(|claimed| -> StdResult<Uint128> { Ok(claimed + redeem_amount) })?;
 
     Ok(Response::new()
-        .set_data(to_binary(&HandleAnswer::Claim {
+        .set_data(to_binary(&ExecuteAnswer::Claim {
             status: ResponseStatus::Success,
             total: account.total_claimable,
             claimed: account_total_claimed_r(deps.storage).load(sender.to_string().as_bytes())?,
@@ -472,7 +476,7 @@ pub fn try_claim_decay(deps: DepsMut, env: &Env, info: &MessageInfo) -> StdResul
                 )?];
 
                 return Ok(Response::new()
-                    .set_data(to_binary(&HandleAnswer::ClaimDecay { status: Success })?));
+                    .set_data(to_binary(&ExecuteAnswer::ClaimDecay { status: Success })?));
             }
         }
     }

--- a/contracts/governance/src/handle/assembly.rs
+++ b/contracts/governance/src/handle/assembly.rs
@@ -19,7 +19,7 @@ use shade_protocol::{
         proposal::{Proposal, ProposalMsg, Status},
         stored_id::{UserID, ID},
         vote::Vote,
-        HandleAnswer,
+        ExecuteAnswer,
         MSG_VARIABLE,
     },
     governance::errors::Error,
@@ -69,7 +69,7 @@ pub fn try_assembly_vote(
     UserID::add_assembly_vote(deps.storage, sender.clone(), proposal.clone())?;
 
     Ok(
-        Response::new().set_data(to_binary(&HandleAnswer::AssemblyVote {
+        Response::new().set_data(to_binary(&ExecuteAnswer::AssemblyVote {
             status: ResponseStatus::Success,
         })?),
     )
@@ -174,7 +174,7 @@ pub fn try_assembly_proposal(
     prop.save(deps.storage)?;
 
     Ok(
-        Response::new().set_data(to_binary(&HandleAnswer::AssemblyProposal {
+        Response::new().set_data(to_binary(&ExecuteAnswer::AssemblyProposal {
             status: ResponseStatus::Success,
         })?),
     )
@@ -205,7 +205,7 @@ pub fn try_add_assembly(
     .save(deps.storage, id)?;
 
     Ok(
-        Response::new().set_data(to_binary(&HandleAnswer::AddAssembly {
+        Response::new().set_data(to_binary(&ExecuteAnswer::AddAssembly {
             status: ResponseStatus::Success,
         })?),
     )
@@ -249,7 +249,7 @@ pub fn try_set_assembly(
     assembly.save(deps.storage, id)?;
 
     Ok(
-        Response::new().set_data(to_binary(&HandleAnswer::SetAssembly {
+        Response::new().set_data(to_binary(&ExecuteAnswer::SetAssembly {
             status: ResponseStatus::Success,
         })?),
     )

--- a/contracts/governance/src/handle/assembly_msg.rs
+++ b/contracts/governance/src/handle/assembly_msg.rs
@@ -3,7 +3,7 @@ use shade_protocol::{
     contract_interfaces::governance::{
         assembly::AssemblyMsg,
         stored_id::ID,
-        HandleAnswer,
+        ExecuteAnswer,
         MSG_VARIABLE,
     },
     governance::errors::Error,
@@ -38,7 +38,7 @@ pub fn try_add_assembly_msg(
     .save(deps.storage, id)?;
 
     Ok(
-        Response::new().set_data(to_binary(&HandleAnswer::AddAssemblyMsg {
+        Response::new().set_data(to_binary(&ExecuteAnswer::AddAssemblyMsg {
             status: ResponseStatus::Success,
         })?),
     )
@@ -73,7 +73,7 @@ pub fn try_set_assembly_msg(
     assembly_msg.save(deps.storage, id)?;
 
     Ok(
-        Response::new().set_data(to_binary(&HandleAnswer::SetAssemblyMsg {
+        Response::new().set_data(to_binary(&ExecuteAnswer::SetAssemblyMsg {
             status: ResponseStatus::Success,
         })?),
     )
@@ -98,7 +98,7 @@ pub fn try_add_assembly_msg_assemblies(
     AssemblyMsg::save_data(deps.storage, id, assembly_msg)?;
 
     Ok(
-        Response::new().set_data(to_binary(&HandleAnswer::SetAssemblyMsg {
+        Response::new().set_data(to_binary(&ExecuteAnswer::SetAssemblyMsg {
             status: ResponseStatus::Success,
         })?),
     )

--- a/contracts/governance/src/handle/contract.rs
+++ b/contracts/governance/src/handle/contract.rs
@@ -1,6 +1,6 @@
 use shade_protocol::{
     c_std::{to_binary, DepsMut, Env, MessageInfo, Response, StdResult},
-    contract_interfaces::governance::{contract::AllowedContract, stored_id::ID, HandleAnswer},
+    contract_interfaces::governance::{contract::AllowedContract, stored_id::ID, ExecuteAnswer},
     governance::errors::Error,
     utils::{asset::Contract, generic_response::ResponseStatus},
 };
@@ -37,7 +37,7 @@ pub fn try_add_contract(
     .save(deps.storage, id)?;
 
     Ok(
-        Response::new().set_data(to_binary(&HandleAnswer::AddContract {
+        Response::new().set_data(to_binary(&ExecuteAnswer::AddContract {
             status: ResponseStatus::Success,
         })?),
     )
@@ -92,7 +92,7 @@ pub fn try_set_contract(
     allowed_contract.save(deps.storage, id)?;
 
     Ok(
-        Response::new().set_data(to_binary(&HandleAnswer::AddContract {
+        Response::new().set_data(to_binary(&ExecuteAnswer::AddContract {
             status: ResponseStatus::Success,
         })?),
     )
@@ -126,7 +126,7 @@ pub fn try_add_contract_assemblies(
     AllowedContract::save_data(deps.storage, id, allowed_contract)?;
 
     Ok(
-        Response::new().set_data(to_binary(&HandleAnswer::AddContractAssemblies {
+        Response::new().set_data(to_binary(&ExecuteAnswer::AddContractAssemblies {
             status: ResponseStatus::Success,
         })?),
     )

--- a/contracts/governance/src/handle/migration.rs
+++ b/contracts/governance/src/handle/migration.rs
@@ -7,8 +7,8 @@ use shade_protocol::{
         profile::Profile,
         stored_id::ID,
         Config,
+        ExecuteAnswer,
         ExecuteMsg::ReceiveMigrationData,
-        HandleAnswer,
         InstantiateMsg,
         MigrationData,
         MigrationDataAsk,
@@ -65,7 +65,7 @@ pub fn try_migrate(
             .to_cosmos_msg(label, id, code_hash, vec![])?,
             0,
         ))
-        .set_data(to_binary(&HandleAnswer::Migrate {
+        .set_data(to_binary(&ExecuteAnswer::Migrate {
             status: ResponseStatus::Success,
         })?))
 }
@@ -158,7 +158,7 @@ pub fn try_migrate_data(
                     .add_message(
                         ReceiveMigrationData { data: res_data }.to_cosmos_msg(&target, vec![])?,
                     )
-                    .set_data(to_binary(&HandleAnswer::MigrateData {
+                    .set_data(to_binary(&ExecuteAnswer::MigrateData {
                         status: ResponseStatus::Success,
                     })?));
             } else {
@@ -209,7 +209,9 @@ pub fn try_receive_migration_data(
         return Err(Error::migration_tartet(vec![]));
     }
 
-    Ok(res.set_data(to_binary(&HandleAnswer::ReceiveMigrationData {
-        status: ResponseStatus::Success,
-    })?))
+    Ok(
+        res.set_data(to_binary(&ExecuteAnswer::ReceiveMigrationData {
+            status: ResponseStatus::Success,
+        })?),
+    )
 }

--- a/contracts/governance/src/handle/mod.rs
+++ b/contracts/governance/src/handle/mod.rs
@@ -1,6 +1,6 @@
 use shade_protocol::{
     c_std::{to_binary, Addr, DepsMut, Env, MessageInfo, Response, StdResult, Storage, SubMsg},
-    contract_interfaces::governance::{Config, HandleAnswer, RuntimeState},
+    contract_interfaces::governance::{Config, ExecuteAnswer, RuntimeState},
     governance::{
         assembly::{Assembly, AssemblyData},
         errors::Error,
@@ -110,7 +110,7 @@ pub fn try_set_config(
 
     config.save(deps.storage)?;
     Ok(Response::new()
-        .set_data(to_binary(&HandleAnswer::SetConfig {
+        .set_data(to_binary(&ExecuteAnswer::SetConfig {
             status: ResponseStatus::Success,
         })?)
         .add_submessages(messages))
@@ -128,7 +128,7 @@ pub fn try_set_runtime_state(
 
     state.save(deps.storage)?;
     Ok(
-        Response::new().set_data(to_binary(&HandleAnswer::SetRuntimeState {
+        Response::new().set_data(to_binary(&ExecuteAnswer::SetRuntimeState {
             status: ResponseStatus::Success,
         })?),
     )

--- a/contracts/governance/src/handle/profile.rs
+++ b/contracts/governance/src/handle/profile.rs
@@ -3,7 +3,7 @@ use shade_protocol::{
     contract_interfaces::governance::{
         profile::{Profile, UpdateProfile},
         stored_id::ID,
-        HandleAnswer,
+        ExecuteAnswer,
     },
     governance::errors::Error,
     utils::generic_response::ResponseStatus,
@@ -19,7 +19,7 @@ pub fn try_add_profile(
     profile.save(deps.storage, id)?;
 
     Ok(
-        Response::new().set_data(to_binary(&HandleAnswer::AddProfile {
+        Response::new().set_data(to_binary(&ExecuteAnswer::AddProfile {
             status: ResponseStatus::Success,
         })?),
     )
@@ -70,7 +70,7 @@ pub fn try_set_profile(
     profile.save(deps.storage, id)?;
 
     Ok(
-        Response::new().set_data(to_binary(&HandleAnswer::SetProfile {
+        Response::new().set_data(to_binary(&ExecuteAnswer::SetProfile {
             status: ResponseStatus::Success,
         })?),
     )

--- a/contracts/governance/src/handle/proposal.rs
+++ b/contracts/governance/src/handle/proposal.rs
@@ -23,7 +23,7 @@ use shade_protocol::{
             stored_id::UserID,
             vote::{ReceiveBalanceMsg, TalliedVotes, Vote},
             Config,
-            HandleAnswer,
+            ExecuteAnswer,
         },
         staking::snip20_staking,
     },
@@ -69,7 +69,7 @@ pub fn try_trigger(
 
     Ok(Response::new()
         .add_submessages(messages)
-        .set_data(to_binary(&HandleAnswer::Trigger {
+        .set_data(to_binary(&ExecuteAnswer::Trigger {
             status: ResponseStatus::Success,
         })?))
 }
@@ -94,7 +94,7 @@ pub fn try_cancel(
         return Err(Error::cannot_cancel(vec![&(-1).to_string()]));
     }
 
-    Ok(Response::new().set_data(to_binary(&HandleAnswer::Cancel {
+    Ok(Response::new().set_data(to_binary(&ExecuteAnswer::Cancel {
         status: ResponseStatus::Success,
     })?))
 }
@@ -313,7 +313,7 @@ pub fn try_update(
     // Save new status
     Proposal::save_status(deps.storage, proposal, new_status.clone())?;
 
-    Ok(Response::new().set_data(to_binary(&HandleAnswer::Update {
+    Ok(Response::new().set_data(to_binary(&ExecuteAnswer::Update {
         status: ResponseStatus::Success,
     })?))
 }
@@ -422,7 +422,7 @@ pub fn try_receive_funding(
         )?);
     }
 
-    Ok(Response::new().set_data(to_binary(&HandleAnswer::Receive {
+    Ok(Response::new().set_data(to_binary(&ExecuteAnswer::Receive {
         status: ResponseStatus::Success,
     })?))
 }
@@ -471,7 +471,7 @@ pub fn try_claim_funding(
             None,
             &funding_token,
         )?)
-        .set_data(to_binary(&HandleAnswer::ClaimFunding {
+        .set_data(to_binary(&ExecuteAnswer::ClaimFunding {
             status: ResponseStatus::Success,
         })?))
 }
@@ -534,7 +534,7 @@ pub fn try_receive_vote(
     UserID::add_vote(deps.storage, sender.clone(), proposal)?;
 
     Ok(
-        Response::new().set_data(to_binary(&HandleAnswer::ReceiveBalance {
+        Response::new().set_data(to_binary(&ExecuteAnswer::ReceiveBalance {
             status: ResponseStatus::Success,
         })?),
     )

--- a/contracts/liability_mint/src/execute.rs
+++ b/contracts/liability_mint/src/execute.rs
@@ -7,7 +7,7 @@ use shade_protocol::snip20::helpers::{self, burn_msg, mint_msg, send_msg, TokenC
 use shade_protocol::snip20::helpers::{token_config, token_info};
 use shade_protocol::{
     dao::adapter,
-    mint::liability_mint::{Config, HandleAnswer},
+    mint::liability_mint::{Config, ExecuteAnswer},
     snip20::helpers::{fetch_snip20, Snip20Asset},
     utils::{asset::Contract, callback::Query, generic_response::ResponseStatus},
 };
@@ -57,7 +57,7 @@ pub fn receive(
 
         Ok(Response::new()
             .add_messages(messages)
-            .set_data(to_binary(&HandleAnswer::Mint {
+            .set_data(to_binary(&ExecuteAnswer::Mint {
                 status: ResponseStatus::Success,
                 amount,
             })?))
@@ -85,7 +85,7 @@ pub fn try_update_config(
     CONFIG.save(deps.storage, &config)?;
 
     Ok(
-        Response::new().set_data(to_binary(&HandleAnswer::UpdateConfig {
+        Response::new().set_data(to_binary(&ExecuteAnswer::UpdateConfig {
             status: ResponseStatus::Success,
         })?),
     )
@@ -172,7 +172,7 @@ pub fn mint(deps: DepsMut, env: Env, info: MessageInfo, amount: Uint128) -> StdR
             None,
             &TOKEN.load(deps.storage)?.contract,
         )?)
-        .set_data(to_binary(&HandleAnswer::Mint {
+        .set_data(to_binary(&ExecuteAnswer::Mint {
             status: ResponseStatus::Success,
             amount,
         })?))
@@ -196,7 +196,7 @@ pub fn add_whitelist(
     WHITELIST.save(deps.storage, &ws)?;
 
     Ok(
-        Response::new().set_data(to_binary(&HandleAnswer::AddWhitelist {
+        Response::new().set_data(to_binary(&ExecuteAnswer::AddWhitelist {
             status: ResponseStatus::Success,
         })?),
     )
@@ -226,7 +226,7 @@ pub fn rm_whitelist(
     WHITELIST.save(deps.storage, &ws)?;
 
     Ok(
-        Response::new().set_data(to_binary(&HandleAnswer::RemoveWhitelist {
+        Response::new().set_data(to_binary(&ExecuteAnswer::RemoveWhitelist {
             status: ResponseStatus::Success,
         })?),
     )
@@ -251,7 +251,7 @@ pub fn add_collateral(
     COLLATERAL.save(deps.storage, &collateral)?;
 
     Ok(
-        Response::new().set_data(to_binary(&HandleAnswer::AddCollateral {
+        Response::new().set_data(to_binary(&ExecuteAnswer::AddCollateral {
             status: ResponseStatus::Success,
         })?),
     )
@@ -281,7 +281,7 @@ pub fn rm_collateral(
     COLLATERAL.save(deps.storage, &collateral)?;
 
     Ok(
-        Response::new().set_data(to_binary(&HandleAnswer::RemoveCollateral {
+        Response::new().set_data(to_binary(&ExecuteAnswer::RemoveCollateral {
             status: ResponseStatus::Success,
         })?),
     )

--- a/contracts/query_auth/src/handle.rs
+++ b/contracts/query_auth/src/handle.rs
@@ -5,7 +5,7 @@ use shade_protocol::{
         auth::{HashedKey, Key, PermitKey},
         Admin,
         ContractStatus,
-        HandleAnswer,
+        ExecuteAnswer,
         RngSeed,
     },
     query_authentication::viewing_keys::ViewingKey,
@@ -38,7 +38,7 @@ pub fn try_set_admin(
 
     Admin(admin).save(deps.storage)?;
 
-    Ok(Response::new().set_data(to_binary(&HandleAnswer::SetAdminAuth { status: Success })?))
+    Ok(Response::new().set_data(to_binary(&ExecuteAnswer::SetAdminAuth { status: Success })?))
 }
 
 pub fn try_set_run_state(
@@ -51,7 +51,7 @@ pub fn try_set_run_state(
 
     state.save(deps.storage)?;
 
-    Ok(Response::new().set_data(to_binary(&HandleAnswer::SetRunState { status: Success })?))
+    Ok(Response::new().set_data(to_binary(&ExecuteAnswer::SetRunState { status: Success })?))
 }
 
 pub fn try_create_viewing_key(
@@ -66,7 +66,7 @@ pub fn try_create_viewing_key(
 
     HashedKey(key.hash()).save(deps.storage, info.sender)?;
 
-    Ok(Response::new().set_data(to_binary(&HandleAnswer::CreateViewingKey { key: key.0 })?))
+    Ok(Response::new().set_data(to_binary(&ExecuteAnswer::CreateViewingKey { key: key.0 })?))
 }
 
 pub fn try_set_viewing_key(
@@ -77,7 +77,7 @@ pub fn try_set_viewing_key(
 ) -> StdResult<Response> {
     HashedKey(Key(key).hash()).save(deps.storage, info.sender)?;
 
-    Ok(Response::new().set_data(to_binary(&HandleAnswer::SetViewingKey { status: Success })?))
+    Ok(Response::new().set_data(to_binary(&ExecuteAnswer::SetViewingKey { status: Success })?))
 }
 
 pub fn try_block_permit_key(
@@ -88,7 +88,7 @@ pub fn try_block_permit_key(
 ) -> StdResult<Response> {
     PermitKey::revoke(deps.storage, key, info.sender)?;
     Ok(
-        Response::new().set_data(to_binary(&HandleAnswer::BlockPermitKey {
+        Response::new().set_data(to_binary(&ExecuteAnswer::BlockPermitKey {
             status: Success,
         })?),
     )

--- a/contracts/query_auth/src/tests/handle.rs
+++ b/contracts/query_auth/src/tests/handle.rs
@@ -238,10 +238,10 @@ fn create_vk() {
     .data
     .unwrap();
 
-    let msg: query_auth::HandleAnswer = from_binary(&data).unwrap();
+    let msg: query_auth::ExecuteAnswer = from_binary(&data).unwrap();
 
     let key = match msg {
-        query_auth::HandleAnswer::CreateViewingKey { key, .. } => key,
+        query_auth::ExecuteAnswer::CreateViewingKey { key, .. } => key,
         _ => {
             assert!(false);
             "doesnt_work".to_string()

--- a/contracts/snip20/src/handle/allowance.rs
+++ b/contracts/snip20/src/handle/allowance.rs
@@ -4,7 +4,7 @@ use shade_protocol::{
     contract_interfaces::snip20::{
         batch,
         manager::{Allowance, CoinInfo},
-        HandleAnswer,
+        ExecuteAnswer,
     },
     utils::{
         generic_response::ResponseStatus::Success,
@@ -42,7 +42,7 @@ pub fn try_increase_allowance(
     allowance.save(deps.storage, (owner.clone(), spender.clone()))?;
 
     Ok(
-        Response::new().set_data(to_binary(&HandleAnswer::IncreaseAllowance {
+        Response::new().set_data(to_binary(&ExecuteAnswer::IncreaseAllowance {
             spender,
             owner,
             allowance: allowance.amount,
@@ -79,7 +79,7 @@ pub fn try_decrease_allowance(
     allowance.save(deps.storage, (owner.clone(), spender.clone()))?;
 
     Ok(
-        Response::new().set_data(to_binary(&HandleAnswer::IncreaseAllowance {
+        Response::new().set_data(to_binary(&ExecuteAnswer::IncreaseAllowance {
             spender,
             owner,
             allowance: allowance.amount,
@@ -108,7 +108,7 @@ pub fn try_transfer_from(
         &env.block,
     )?;
 
-    Ok(Response::new().set_data(to_binary(&HandleAnswer::TransferFrom { status: Success })?))
+    Ok(Response::new().set_data(to_binary(&ExecuteAnswer::TransferFrom { status: Success })?))
 }
 
 pub fn try_batch_transfer_from(
@@ -133,7 +133,7 @@ pub fn try_batch_transfer_from(
     }
 
     Ok(
-        Response::new().set_data(to_binary(&HandleAnswer::BatchTransferFrom {
+        Response::new().set_data(to_binary(&ExecuteAnswer::BatchTransferFrom {
             status: Success,
         })?),
     )
@@ -167,7 +167,7 @@ pub fn try_send_from(
     )?;
 
     Ok(Response::new()
-        .set_data(to_binary(&HandleAnswer::SendFrom { status: Success })?)
+        .set_data(to_binary(&ExecuteAnswer::SendFrom { status: Success })?)
         .add_submessages(messages))
 }
 
@@ -198,6 +198,6 @@ pub fn try_batch_send_from(
     }
 
     Ok(Response::new()
-        .set_data(to_binary(&HandleAnswer::BatchSendFrom { status: Success })?)
+        .set_data(to_binary(&ExecuteAnswer::BatchSendFrom { status: Success })?)
         .add_submessages(messages))
 }

--- a/contracts/snip20/src/handle/burning.rs
+++ b/contracts/snip20/src/handle/burning.rs
@@ -5,7 +5,7 @@ use shade_protocol::{
         errors::burning_disabled,
         manager::{Allowance, Balance, CoinInfo, Config, TotalSupply},
         transaction_history::store_burn,
-        HandleAnswer,
+        ExecuteAnswer,
     },
     utils::{generic_response::ResponseStatus::Success, storage::plus::ItemStorage},
 };
@@ -39,7 +39,7 @@ pub fn try_burn(
         &env.block,
     )?;
 
-    Ok(Response::new().set_data(to_binary(&HandleAnswer::Burn { status: Success })?))
+    Ok(Response::new().set_data(to_binary(&ExecuteAnswer::Burn { status: Success })?))
 }
 
 pub fn try_burn_from(
@@ -73,7 +73,7 @@ pub fn try_burn_from(
         &env.block,
     )?;
 
-    Ok(Response::new().set_data(to_binary(&HandleAnswer::BurnFrom { status: Success })?))
+    Ok(Response::new().set_data(to_binary(&ExecuteAnswer::BurnFrom { status: Success })?))
 }
 
 pub fn try_batch_burn_from(
@@ -123,5 +123,5 @@ pub fn try_batch_burn_from(
 
     supply.save(deps.storage)?;
 
-    Ok(Response::new().set_data(to_binary(&HandleAnswer::BatchBurnFrom { status: Success })?))
+    Ok(Response::new().set_data(to_binary(&ExecuteAnswer::BatchBurnFrom { status: Success })?))
 }

--- a/contracts/snip20/src/handle/minting.rs
+++ b/contracts/snip20/src/handle/minting.rs
@@ -5,7 +5,7 @@ use shade_protocol::{
         errors::{minting_disabled, not_admin, not_minter},
         manager::{Admin, Balance, CoinInfo, Config, Minters, TotalSupply},
         transaction_history::store_mint,
-        HandleAnswer,
+        ExecuteAnswer,
     },
     utils::{generic_response::ResponseStatus::Success, storage::plus::ItemStorage},
 };
@@ -55,7 +55,7 @@ pub fn try_mint(
         &block,
     )?;
 
-    Ok(Response::new().set_data(to_binary(&HandleAnswer::Mint { status: Success })?))
+    Ok(Response::new().set_data(to_binary(&ExecuteAnswer::Mint { status: Success })?))
 }
 
 pub fn try_batch_mint(
@@ -91,7 +91,7 @@ pub fn try_batch_mint(
     }
     supply.save(deps.storage)?;
 
-    Ok(Response::new().set_data(to_binary(&HandleAnswer::BatchMint { status: Success })?))
+    Ok(Response::new().set_data(to_binary(&ExecuteAnswer::BatchMint { status: Success })?))
 }
 
 pub fn try_add_minters(
@@ -112,7 +112,7 @@ pub fn try_add_minters(
     minters.0.extend(new_minters);
     minters.save(deps.storage)?;
 
-    Ok(Response::new().set_data(to_binary(&HandleAnswer::AddMinters { status: Success })?))
+    Ok(Response::new().set_data(to_binary(&ExecuteAnswer::AddMinters { status: Success })?))
 }
 
 pub fn try_remove_minters(
@@ -135,7 +135,7 @@ pub fn try_remove_minters(
     }
     minters.save(deps.storage)?;
 
-    Ok(Response::new().set_data(to_binary(&HandleAnswer::RemoveMinters { status: Success })?))
+    Ok(Response::new().set_data(to_binary(&ExecuteAnswer::RemoveMinters { status: Success })?))
 }
 
 pub fn try_set_minters(
@@ -154,5 +154,5 @@ pub fn try_set_minters(
 
     Minters(minters).save(deps.storage)?;
 
-    Ok(Response::new().set_data(to_binary(&HandleAnswer::SetMinters { status: Success })?))
+    Ok(Response::new().set_data(to_binary(&ExecuteAnswer::SetMinters { status: Success })?))
 }

--- a/contracts/snip20/src/handle/mod.rs
+++ b/contracts/snip20/src/handle/mod.rs
@@ -40,7 +40,7 @@ use shade_protocol::{
             TotalSupply,
         },
         transaction_history::{store_deposit, store_redeem},
-        HandleAnswer,
+        ExecuteAnswer,
     },
     query_authentication::viewing_keys::ViewingKey,
     snip20::manager::QueryAuth,
@@ -89,7 +89,7 @@ pub fn try_redeem(
             to_address: sender.into(),
             amount: withdrawal_coins,
         }))
-        .set_data(to_binary(&HandleAnswer::Redeem { status: Success })?))
+        .set_data(to_binary(&ExecuteAnswer::Redeem { status: Success })?))
 }
 
 pub fn try_deposit(deps: DepsMut, env: Env, info: MessageInfo) -> StdResult<Response> {
@@ -123,7 +123,7 @@ pub fn try_deposit(deps: DepsMut, env: Env, info: MessageInfo) -> StdResult<Resp
         &env.block,
     )?;
 
-    Ok(Response::new().set_data(to_binary(&HandleAnswer::Deposit { status: Success })?))
+    Ok(Response::new().set_data(to_binary(&ExecuteAnswer::Deposit { status: Success })?))
 }
 
 pub fn try_change_admin(
@@ -138,7 +138,7 @@ pub fn try_change_admin(
 
     Admin(address).save(deps.storage)?;
 
-    Ok(Response::new().set_data(to_binary(&HandleAnswer::ChangeAdmin { status: Success })?))
+    Ok(Response::new().set_data(to_binary(&ExecuteAnswer::ChangeAdmin { status: Success })?))
 }
 
 pub fn try_update_query_auth(
@@ -158,7 +158,7 @@ pub fn try_update_query_auth(
     }
 
     Ok(
-        Response::new().set_data(to_binary(&HandleAnswer::UpdateQueryAuth {
+        Response::new().set_data(to_binary(&ExecuteAnswer::UpdateQueryAuth {
             status: Success,
         })?),
     )
@@ -177,7 +177,7 @@ pub fn try_set_contract_status(
     status_level.save(deps.storage)?;
 
     Ok(
-        Response::new().set_data(to_binary(&HandleAnswer::SetContractStatus {
+        Response::new().set_data(to_binary(&ExecuteAnswer::SetContractStatus {
             status: Success,
         })?),
     )
@@ -191,7 +191,7 @@ pub fn try_register_receive(
 ) -> StdResult<Response> {
     ReceiverHash(code_hash).save(deps.storage, info.sender)?;
     Ok(
-        Response::new().set_data(to_binary(&HandleAnswer::RegisterReceive {
+        Response::new().set_data(to_binary(&ExecuteAnswer::RegisterReceive {
             status: Success,
         })?),
     )
@@ -209,7 +209,7 @@ pub fn try_create_viewing_key(
 
     HashedKey(key.hash()).save(deps.storage, info.sender)?;
 
-    Ok(Response::new().set_data(to_binary(&HandleAnswer::CreateViewingKey { key: key.0 })?))
+    Ok(Response::new().set_data(to_binary(&ExecuteAnswer::CreateViewingKey { key: key.0 })?))
 }
 
 pub fn try_set_viewing_key(
@@ -223,7 +223,7 @@ pub fn try_set_viewing_key(
 
     HashedKey(Key(key).hash()).save(deps.storage, info.sender)?;
 
-    Ok(Response::new().set_data(to_binary(&HandleAnswer::SetViewingKey { status: Success })?))
+    Ok(Response::new().set_data(to_binary(&ExecuteAnswer::SetViewingKey { status: Success })?))
 }
 
 pub fn try_revoke_permit(
@@ -234,5 +234,5 @@ pub fn try_revoke_permit(
 ) -> StdResult<Response> {
     PermitKey::revoke(deps.storage, permit_name, info.sender)?;
 
-    Ok(Response::new().set_data(to_binary(&HandleAnswer::RevokePermit { status: Success })?))
+    Ok(Response::new().set_data(to_binary(&ExecuteAnswer::RevokePermit { status: Success })?))
 }

--- a/contracts/snip20/src/handle/transfers.rs
+++ b/contracts/snip20/src/handle/transfers.rs
@@ -17,7 +17,7 @@ use shade_protocol::{
         errors::transfer_disabled,
         manager::{Allowance, Balance, CoinInfo, Config, ReceiverHash},
         transaction_history::store_transfer,
-        HandleAnswer,
+        ExecuteAnswer,
         ReceiverHandleMsg,
     },
     utils::{
@@ -78,7 +78,7 @@ pub fn try_transfer(
         &env.block,
     )?;
 
-    Ok(Response::new().set_data(to_binary(&HandleAnswer::Transfer { status: Success })?))
+    Ok(Response::new().set_data(to_binary(&ExecuteAnswer::Transfer { status: Success })?))
 }
 
 pub fn try_batch_transfer(
@@ -102,7 +102,7 @@ pub fn try_batch_transfer(
             &block,
         )?;
     }
-    Ok(Response::new().set_data(to_binary(&HandleAnswer::BatchTransfer { status: Success })?))
+    Ok(Response::new().set_data(to_binary(&ExecuteAnswer::BatchTransfer { status: Success })?))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -203,7 +203,7 @@ pub fn try_send(
     )?;
 
     Ok(Response::new()
-        .set_data(to_binary(&HandleAnswer::Send { status: Success })?)
+        .set_data(to_binary(&ExecuteAnswer::Send { status: Success })?)
         .add_submessages(messages))
 }
 
@@ -234,6 +234,6 @@ pub fn try_batch_send(
     }
 
     Ok(Response::new()
-        .set_data(to_binary(&HandleAnswer::BatchSend { status: Success })?)
+        .set_data(to_binary(&ExecuteAnswer::BatchSend { status: Success })?)
         .add_submessages(messages))
 }

--- a/packages/shade_protocol/Cargo.toml
+++ b/packages/shade_protocol/Cargo.toml
@@ -9,6 +9,15 @@ authors = [
 ]
 edition = "2018"
 
+[[bin]]
+name = "schemas"
+path = "src/schemas.rs"
+# Must have all of the contract_interfaces
+required-features = [
+  "admin", "airdrop", "bonds", "dao", "dex", "governance-impl", "mint", "oracles",
+  "peg_stability", "query_auth", "sky", "snip20", "staking"
+]
+
 [lib]
 crate-type = ["cdylib", "rlib"]
 

--- a/packages/shade_protocol/Cargo.toml
+++ b/packages/shade_protocol/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/schemas.rs"
 # Must have all of the contract_interfaces
 required-features = [
   "admin", "airdrop", "bonds", "dao", "dex", "governance-impl", "mint", "oracles",
-  "peg_stability", "query_auth", "sky", "snip20", "staking"
+  "peg_stability", "query_auth", "sky", "snip20", "staking", "mint_router"
 ]
 
 [lib]

--- a/packages/shade_protocol/src/contract_interfaces/airdrop/mod.rs
+++ b/packages/shade_protocol/src/contract_interfaces/airdrop/mod.rs
@@ -3,16 +3,16 @@ pub mod claim_info;
 pub mod errors;
 
 use crate::{
+    c_std::{Addr, Binary, Uint128},
     contract_interfaces::airdrop::{
         account::{AccountPermit, AddressProofPermit},
         claim_info::RequiredTask,
     },
     utils::{asset::Contract, generic_response::ResponseStatus},
 };
-use crate::c_std::{Uint128, Binary, Addr};
 
 use crate::utils::{ExecuteCallback, InstantiateCallback, Query};
-use cosmwasm_schema::{cw_serde};
+use cosmwasm_schema::cw_serde;
 
 #[cw_serde]
 pub struct Config {
@@ -121,7 +121,7 @@ impl ExecuteCallback for ExecuteMsg {
 }
 
 #[cw_serde]
-pub enum HandleAnswer {
+pub enum ExecuteAnswer {
     UpdateConfig {
         status: ResponseStatus,
     },

--- a/packages/shade_protocol/src/contract_interfaces/bonds/mod.rs
+++ b/packages/shade_protocol/src/contract_interfaces/bonds/mod.rs
@@ -2,22 +2,29 @@ pub mod errors;
 pub mod rand;
 pub mod utils;
 
-use cosmwasm_std::MessageInfo;
 use crate::c_std::Env;
+use cosmwasm_std::MessageInfo;
 
-use crate::contract_interfaces::bonds::rand::{sha_256, Prng};
-use crate::contract_interfaces::bonds::utils::{
-    create_hashed_password, ct_slice_compare, VIEWING_KEY_PREFIX, VIEWING_KEY_SIZE,
+use crate::{
+    c_std::{Addr, Binary, Uint128},
+    contract_interfaces::{
+        bonds::{
+            rand::{sha_256, Prng},
+            utils::{
+                create_hashed_password,
+                ct_slice_compare,
+                VIEWING_KEY_PREFIX,
+                VIEWING_KEY_SIZE,
+            },
+        },
+        query_auth::QueryPermit,
+        snip20::helpers::Snip20Asset,
+    },
+    utils::{asset::Contract, generic_response::ResponseStatus},
 };
-use crate::contract_interfaces::snip20::helpers::Snip20Asset;
-use crate::contract_interfaces::query_auth::QueryPermit;
-use crate::utils::asset::Contract;
-use crate::utils::generic_response::ResponseStatus;
-use crate::c_std::Uint128;
-use crate::c_std::{Binary, Addr};
 
 use crate::utils::ExecuteCallback;
-use cosmwasm_schema::{cw_serde};
+use cosmwasm_schema::cw_serde;
 
 #[cw_serde]
 pub struct Config {
@@ -121,7 +128,7 @@ impl ExecuteCallback for ExecuteMsg {
 }
 
 #[cw_serde]
-pub enum HandleAnswer {
+pub enum ExecuteAnswer {
     UpdateLimitConfig {
         status: ResponseStatus,
     },

--- a/packages/shade_protocol/src/contract_interfaces/dao/lp_shade_swap.rs
+++ b/packages/shade_protocol/src/contract_interfaces/dao/lp_shade_swap.rs
@@ -85,7 +85,7 @@ impl ExecuteCallback for ExecuteMsg {
 }
 
 #[cw_serde]
-pub enum HandleAnswer {
+pub enum ExecuteAnswer {
     Init {
         status: ResponseStatus,
         address: Addr,

--- a/packages/shade_protocol/src/contract_interfaces/dao/rewards_emission.rs
+++ b/packages/shade_protocol/src/contract_interfaces/dao/rewards_emission.rs
@@ -1,11 +1,11 @@
 use crate::{
+    c_std::{Addr, Binary, Decimal, Delegation, Uint128, Validator},
     contract_interfaces::dao::adapter,
     utils::{asset::Contract, generic_response::ResponseStatus},
 };
-use crate::c_std::{Binary, Decimal, Delegation, Addr, Uint128, Validator};
 
 use crate::utils::{ExecuteCallback, InstantiateCallback, Query};
-use cosmwasm_schema::{cw_serde};
+use cosmwasm_schema::cw_serde;
 
 #[cw_serde]
 pub struct Reward {
@@ -58,7 +58,7 @@ impl ExecuteCallback for ExecuteMsg {
 }
 
 #[cw_serde]
-pub enum HandleAnswer {
+pub enum ExecuteAnswer {
     Init {
         status: ResponseStatus,
         address: Addr,

--- a/packages/shade_protocol/src/contract_interfaces/governance/mod.rs
+++ b/packages/shade_protocol/src/contract_interfaces/governance/mod.rs
@@ -298,7 +298,7 @@ impl ExecuteCallback for ExecuteMsg {
 }
 
 #[cw_serde]
-pub enum HandleAnswer {
+pub enum ExecuteAnswer {
     SetConfig { status: ResponseStatus },
     SetRuntimeState { status: ResponseStatus },
     Proposal { status: ResponseStatus },

--- a/packages/shade_protocol/src/contract_interfaces/mint/liability_mint.rs
+++ b/packages/shade_protocol/src/contract_interfaces/mint/liability_mint.rs
@@ -1,6 +1,5 @@
-use crate::c_std::Uint128;
-use crate::c_std::{Addr, Binary};
 use crate::{
+    c_std::{Addr, Binary, Uint128},
     contract_interfaces::snip20::helpers::Snip20Asset,
     utils::{asset::Contract, generic_response::ResponseStatus},
 };
@@ -70,7 +69,7 @@ impl ExecuteCallback for ExecuteMsg {
 }
 
 #[cw_serde]
-pub enum HandleAnswer {
+pub enum ExecuteAnswer {
     Init {
         status: ResponseStatus,
         address: Addr,

--- a/packages/shade_protocol/src/contract_interfaces/mint/mint.rs
+++ b/packages/shade_protocol/src/contract_interfaces/mint/mint.rs
@@ -107,7 +107,7 @@ pub struct MintMsgHook {
 }
 
 #[cw_serde]
-pub enum HandleAnswer {
+pub enum ExecuteAnswer {
     Init {
         status: ResponseStatus,
         address: Addr,

--- a/packages/shade_protocol/src/contract_interfaces/mint/mint_router.rs
+++ b/packages/shade_protocol/src/contract_interfaces/mint/mint_router.rs
@@ -1,12 +1,11 @@
 use crate::{
+    c_std::{Addr, Binary, Uint128},
     contract_interfaces::snip20::helpers::Snip20Asset,
     utils::{asset::Contract, generic_response::ResponseStatus},
 };
-use crate::c_std::Uint128;
-use crate::c_std::{Binary, Addr};
 
 use crate::utils::{ExecuteCallback, InstantiateCallback, Query};
-use cosmwasm_schema::{cw_serde};
+use cosmwasm_schema::cw_serde;
 
 #[cw_serde]
 pub struct Config {
@@ -60,7 +59,7 @@ impl ExecuteCallback for ExecuteMsg {
 }
 
 #[cw_serde]
-pub enum HandleAnswer {
+pub enum ExecuteAnswer {
     Init {
         status: ResponseStatus,
         address: Addr,

--- a/packages/shade_protocol/src/contract_interfaces/mod.rs
+++ b/packages/shade_protocol/src/contract_interfaces/mod.rs
@@ -21,9 +21,6 @@ pub mod snip20;
 #[cfg(feature = "airdrop")]
 pub mod airdrop;
 
-#[cfg(feature = "initializer")]
-pub mod initializer;
-
 // Protocol libraries
 #[cfg(feature = "governance")]
 pub mod governance;

--- a/packages/shade_protocol/src/contract_interfaces/oracles/oracle.rs
+++ b/packages/shade_protocol/src/contract_interfaces/oracles/oracle.rs
@@ -62,7 +62,7 @@ impl ExecuteCallback for ExecuteMsg {
 }
 
 #[cw_serde]
-pub enum HandleAnswer {
+pub enum ExecuteAnswer {
     UpdateConfig {
         status: ResponseStatus,
     },

--- a/packages/shade_protocol/src/contract_interfaces/query_auth/mod.rs
+++ b/packages/shade_protocol/src/contract_interfaces/query_auth/mod.rs
@@ -2,18 +2,24 @@
 pub mod auth;
 pub mod helpers;
 
-use crate::c_std::{Binary, Addr};
+use crate::c_std::{Addr, Binary};
 
-use crate::query_authentication::permit::Permit;
-use crate::utils::{ExecuteCallback, InstantiateCallback, Query};
-use cosmwasm_schema::{cw_serde};
-use crate::utils::generic_response::ResponseStatus;
 #[cfg(feature = "query_auth_impl")]
 use crate::utils::storage::plus::ItemStorage;
+use crate::{
+    query_authentication::permit::Permit,
+    utils::{
+        asset::Contract,
+        crypto::sha_256,
+        generic_response::ResponseStatus,
+        ExecuteCallback,
+        InstantiateCallback,
+        Query,
+    },
+};
+use cosmwasm_schema::cw_serde;
 #[cfg(feature = "query_auth_impl")]
 use secret_storage_plus::Item;
-use crate::utils::crypto::sha_256;
-use crate::utils::asset::Contract;
 
 #[cfg(feature = "query_auth_impl")]
 #[cw_serde]
@@ -43,7 +49,7 @@ impl RngSeed {
 #[cw_serde]
 pub struct InstantiateMsg {
     pub admin_auth: Contract,
-    pub prng_seed: Binary
+    pub prng_seed: Binary,
 }
 
 impl InstantiateCallback for InstantiateMsg {
@@ -55,7 +61,7 @@ pub enum ContractStatus {
     Default,
     DisablePermit,
     DisableVK,
-    DisableAll
+    DisableAll,
 }
 
 #[cfg(feature = "query_auth_impl")]
@@ -86,7 +92,7 @@ pub enum ExecuteMsg {
     BlockPermitKey {
         key: String,
         padding: Option<String>,
-    }
+    },
 }
 
 impl ExecuteCallback for ExecuteMsg {
@@ -94,22 +100,12 @@ impl ExecuteCallback for ExecuteMsg {
 }
 
 #[cw_serde]
-pub enum HandleAnswer {
-    SetAdminAuth {
-        status: ResponseStatus
-    },
-    SetRunState {
-        status: ResponseStatus
-    },
-    SetViewingKey {
-        status: ResponseStatus
-    },
-    CreateViewingKey {
-        key: String
-    },
-    BlockPermitKey {
-        status: ResponseStatus
-    },
+pub enum ExecuteAnswer {
+    SetAdminAuth { status: ResponseStatus },
+    SetRunState { status: ResponseStatus },
+    SetViewingKey { status: ResponseStatus },
+    CreateViewingKey { key: String },
+    BlockPermitKey { status: ResponseStatus },
 }
 
 pub type QueryPermit = Permit<PermitData>;
@@ -125,13 +121,8 @@ pub struct PermitData {
 pub enum QueryMsg {
     Config {},
 
-    ValidateViewingKey {
-        user: Addr,
-        key: String,
-    },
-    ValidatePermit {
-        permit: QueryPermit
-    }
+    ValidateViewingKey { user: Addr, key: String },
+    ValidatePermit { permit: QueryPermit },
 }
 
 impl Query for QueryMsg {
@@ -142,15 +133,13 @@ impl Query for QueryMsg {
 pub enum QueryAnswer {
     Config {
         admin: Contract,
-        state: ContractStatus
+        state: ContractStatus,
     },
     ValidateViewingKey {
-        is_valid: bool
+        is_valid: bool,
     },
     ValidatePermit {
         user: Addr,
-        is_revoked: bool
-    }
+        is_revoked: bool,
+    },
 }
-
-

--- a/packages/shade_protocol/src/contract_interfaces/snip20/mod.rs
+++ b/packages/shade_protocol/src/contract_interfaces/snip20/mod.rs
@@ -419,7 +419,7 @@ impl ExecuteCallback for ReceiverHandleMsg {
 }
 
 #[cw_serde]
-pub enum HandleAnswer {
+pub enum ExecuteAnswer {
     // Native
     Deposit {
         status: ResponseStatus,

--- a/packages/shade_protocol/src/contract_interfaces/staking/snip20_staking/mod.rs
+++ b/packages/shade_protocol/src/contract_interfaces/staking/snip20_staking/mod.rs
@@ -1,15 +1,15 @@
 pub mod stake;
 use crate::{
+    c_std::{Addr, Binary, Uint128},
     contract_interfaces::{
         snip20::QueryPermit,
         staking::snip20_staking::stake::{QueueItem, StakeConfig, VecQueue},
     },
     utils::{asset::Contract, generic_response::ResponseStatus},
 };
-use crate::c_std::{Binary, Addr, Uint128};
 
 use crate::utils::{ExecuteCallback, Query};
-use cosmwasm_schema::{cw_serde};
+use cosmwasm_schema::cw_serde;
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -130,7 +130,7 @@ impl ExecuteCallback for ExecuteMsg {
 }
 
 #[cw_serde]
-pub enum HandleAnswer {
+pub enum ExecuteAnswer {
     UpdateStakeConfig { status: ResponseStatus },
     Receive { status: ResponseStatus },
     Unbond { status: ResponseStatus },

--- a/packages/shade_protocol/src/schemas.rs
+++ b/packages/shade_protocol/src/schemas.rs
@@ -2,7 +2,6 @@ use cosmwasm_schema::{export_schema, remove_schemas};
 use schemars::schema_for;
 use std::{env::current_dir, fs::create_dir_all};
 
-#[macro_export]
 macro_rules! generate_schemas {
     ($($Contract:ident),+) => {
         $(
@@ -10,6 +9,27 @@ macro_rules! generate_schemas {
 
             let mut out_dir = current_dir().unwrap();
             out_dir.push("schema");
+            out_dir.push(stringify!($Contract));
+            create_dir_all(&out_dir).unwrap();
+            remove_schemas(&out_dir).unwrap();
+
+            export_schema(&schema_for!($Contract::InstantiateMsg), &out_dir);
+            export_schema(&schema_for!($Contract::ExecuteMsg), &out_dir);
+            export_schema(&schema_for!($Contract::ExecuteAnswer), &out_dir);
+            export_schema(&schema_for!($Contract::QueryMsg), &out_dir);
+            export_schema(&schema_for!($Contract::QueryAnswer), &out_dir);
+        )+
+    };
+}
+
+macro_rules! generate_nested_schemas {
+    ($Folder:ident, $($Contract:ident),+) => {
+        $(
+            use shade_protocol::contract_interfaces::$Folder::$Contract;
+
+            let mut out_dir = current_dir().unwrap();
+            out_dir.push("schema");
+            out_dir.push(stringify!($Folder));
             out_dir.push(stringify!($Contract));
             create_dir_all(&out_dir).unwrap();
             remove_schemas(&out_dir).unwrap();
@@ -34,5 +54,24 @@ pub fn main() {
         snip20
     );
 
-    //TODO: custom impl for admin, mint, oracles, dex, dao and staking
+    generate_nested_schemas!(mint, liability_mint, mint, mint_router);
+
+    generate_nested_schemas!(oracles, oracle);
+
+    generate_nested_schemas!(dao, treasury_manager, treasury, scrt_staking);
+
+    generate_nested_schemas!(staking, snip20_staking);
+
+    // TODO: make admin interface up to standard
+    use shade_protocol::contract_interfaces::admin;
+
+    let mut out_dir = current_dir().unwrap();
+    out_dir.push("schema");
+    out_dir.push("admin");
+    create_dir_all(&out_dir).unwrap();
+    remove_schemas(&out_dir).unwrap();
+
+    export_schema(&schema_for!(admin::InstantiateMsg), &out_dir);
+    export_schema(&schema_for!(admin::ExecuteMsg), &out_dir);
+    export_schema(&schema_for!(admin::QueryMsg), &out_dir);
 }

--- a/packages/shade_protocol/src/schemas.rs
+++ b/packages/shade_protocol/src/schemas.rs
@@ -1,0 +1,38 @@
+use cosmwasm_schema::{export_schema, remove_schemas};
+use schemars::schema_for;
+use std::{env::current_dir, fs::create_dir_all};
+
+#[macro_export]
+macro_rules! generate_schemas {
+    ($($Contract:ident),+) => {
+        $(
+            use shade_protocol::contract_interfaces::$Contract;
+
+            let mut out_dir = current_dir().unwrap();
+            out_dir.push("schema");
+            out_dir.push(stringify!($Contract));
+            create_dir_all(&out_dir).unwrap();
+            remove_schemas(&out_dir).unwrap();
+
+            export_schema(&schema_for!($Contract::InstantiateMsg), &out_dir);
+            export_schema(&schema_for!($Contract::ExecuteMsg), &out_dir);
+            export_schema(&schema_for!($Contract::ExecuteAnswer), &out_dir);
+            export_schema(&schema_for!($Contract::QueryMsg), &out_dir);
+            export_schema(&schema_for!($Contract::QueryAnswer), &out_dir);
+        )+
+    };
+}
+
+pub fn main() {
+    generate_schemas!(
+        airdrop,
+        bonds,
+        governance,
+        peg_stability,
+        query_auth,
+        sky,
+        snip20
+    );
+
+    //TODO: custom impl for admin, mint, oracles, dex, dao and staking
+}


### PR DESCRIPTION
<!-- NOTE: Listed items are examples and should be removed when making a PR -->

# Description
<!-- Quick description of what this PR achieves -->

<!-- If it tackles any issue use something like - Fixes # (issue) -->

Wrapped schema generation around a macro to make supporting the frontend team as easy as possible, for the meantime whenever a new contract interface is created you need to add its feature under `[tasks.schema]` inside `Makefile.toml`

To add the interface to be generated you need to add it inside `packages/shade_protocol/src/schema.rs`

To generate simply run `cargo make schemas`

## Notable changes

<!-- List what the notable changes are -->

- Schemas are easy to generate
- Renamed many interfaces that used `HandleAnswer` instead of `ExecuteAnswer`
