### PR TITLE
Allow issued asset as deposit (allows SHD for SHD)

### DIFF
--- a/contracts/bonds/src/handle.rs
+++ b/contracts/bonds/src/handle.rs
@@ -210,11 +210,6 @@ pub fn try_deposit<S: Storage, A: Api, Q: Querier>(
         return Err(blacklisted(sender));
     }
 
-    // Check that sender isn't the minted asset
-    if config.issued_asset.address == env.message.sender {
-        return Err(issued_asset_deposit());
-    }
-
     // Check that sender asset has an active bond opportunity
     let bond_opportunity = match bond_opportunity_r(&deps.storage)
         .may_load(env.message.sender.to_string().as_bytes())?
@@ -236,7 +231,7 @@ pub fn try_deposit<S: Storage, A: Api, Q: Querier>(
     // Load mint asset information
     let issuance_asset = issued_asset_r(&deps.storage).load()?;
 
-    // Calculate conversion of deposit to SHD
+    // Calculate conversion of deposit to issued
     let (amount_to_issue, deposit_price, claim_price, discount_price) = amount_to_issue(
         &deps,
         deposit_amount,

--- a/contracts/bonds/src/tests/handle.rs
+++ b/contracts/bonds/src/tests/handle.rs
@@ -16,7 +16,7 @@ use super::{increase_allowance, query::{query_acccount_parameters, query_bonds_b
 #[test]
 pub fn test_bonds() {
     let (mut chain, bonds, issu, depo, atom, band, _oracle, query_auth, shade_admins) =
-        init_contracts().unwrap();
+        init_contracts(false).unwrap();
 
     set_prices(
         &mut chain,
@@ -503,7 +503,25 @@ fn update_config(
 #[test]
 pub fn test_shd_shd_bond() {
     let (mut chain, bonds, issu, depo, _atom, band, _oracle, query_auth, shade_admins) =
-        init_contracts().unwrap();
+        init_contracts(true).unwrap();
+
+    update_config(
+        &mut chain,
+        &bonds,
+        "admin",
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(Uint128::new(9_500_000_000_000_000_000)),
+        None,
+        None,
+        None,
+        None,
+    );
 
     set_prices(
         &mut chain,

--- a/contracts/bonds/src/tests/mod.rs
+++ b/contracts/bonds/src/tests/mod.rs
@@ -21,7 +21,7 @@ use shade_oracles::{
     router,
 };
 
-pub fn init_contracts() -> StdResult<(
+pub fn init_contracts(seed_user: bool) -> StdResult<(
     ContractEnsemble,
     ContractLink<HumanAddr>,
     ContractLink<HumanAddr>,
@@ -52,6 +52,26 @@ pub fn init_contracts() -> StdResult<(
 
     // Register snip20s
     let issu = chain.register(Box::new(Snip20));
+    let mut balances;
+    if seed_user {
+        balances = vec![
+            InitialBalance {
+                address: HumanAddr::from("admin"),
+                amount: Uint128::new(1_000_000_000_000_000),
+            },
+            InitialBalance {
+                address: HumanAddr::from("secret19rla95xfp22je7hyxv7h0nhm6cwtwahu69zraq"),
+                amount: Uint128::new(1_000_000_000_000_000),
+            }
+        ];
+    } else {
+        balances = vec![
+            InitialBalance {
+                address: HumanAddr::from("admin"),
+                amount: Uint128::new(1_000_000_000_000_000),
+            },
+        ]
+    }
     let issu = chain
         .instantiate(
             issu.id,
@@ -60,16 +80,7 @@ pub fn init_contracts() -> StdResult<(
                 admin: Some(HumanAddr::from("admin")),
                 symbol: "ISSU".into(),
                 decimals: 8,
-                initial_balances: Some(vec![
-                    InitialBalance {
-                        address: HumanAddr::from("admin"),
-                        amount: Uint128::new(1_000_000_000_000_000),
-                    },
-                    InitialBalance {
-                        address: HumanAddr::from("secret19rla95xfp22je7hyxv7h0nhm6cwtwahu69zraq"),
-                        amount: Uint128::new(1_000_000_000_000_000),
-                    }
-                ]),
+                initial_balances: Some(balances),
                 prng_seed: Default::default(),
                 config: None,
             },
@@ -362,7 +373,7 @@ pub fn init_contracts() -> StdResult<(
                 bond_issuance_limit: Uint128::new(100_000_000_000_000),
                 bonding_period: 0,
                 discount: Uint128::new(10_000),
-                global_min_accepted_issued_price: Uint128::new(9_000_000_000_000_000_000),
+                global_min_accepted_issued_price: Uint128::new(10_000_000_000_000_000_000),
                 global_err_issued_price: Uint128::new(5_000_000_000_000_000_000),
                 allowance_key_entropy: "".into(),
                 airdrop: None,

--- a/contracts/bonds/src/tests/mod.rs
+++ b/contracts/bonds/src/tests/mod.rs
@@ -60,10 +60,16 @@ pub fn init_contracts() -> StdResult<(
                 admin: Some(HumanAddr::from("admin")),
                 symbol: "ISSU".into(),
                 decimals: 8,
-                initial_balances: Some(vec![InitialBalance {
-                    address: HumanAddr::from("admin"),
-                    amount: Uint128::new(1_000_000_000_000_000),
-                }]),
+                initial_balances: Some(vec![
+                    InitialBalance {
+                        address: HumanAddr::from("admin"),
+                        amount: Uint128::new(1_000_000_000_000_000),
+                    },
+                    InitialBalance {
+                        address: HumanAddr::from("secret19rla95xfp22je7hyxv7h0nhm6cwtwahu69zraq"),
+                        amount: Uint128::new(1_000_000_000_000_000),
+                    }
+                ]),
                 prng_seed: Default::default(),
                 config: None,
             },
@@ -356,7 +362,7 @@ pub fn init_contracts() -> StdResult<(
                 bond_issuance_limit: Uint128::new(100_000_000_000_000),
                 bonding_period: 0,
                 discount: Uint128::new(10_000),
-                global_min_accepted_issued_price: Uint128::new(10_000_000_000_000_000_000),
+                global_min_accepted_issued_price: Uint128::new(9_000_000_000_000_000_000),
                 global_err_issued_price: Uint128::new(5_000_000_000_000_000_000),
                 allowance_key_entropy: "".into(),
                 airdrop: None,

--- a/contracts/bonds/src/tests/query.rs
+++ b/contracts/bonds/src/tests/query.rs
@@ -24,6 +24,19 @@ pub fn query_no_opps(chain: &mut ContractEnsemble, bonds: &ContractLink<HumanAdd
     }
 }
 
+pub fn query_bonds_balance(chain: &mut ContractEnsemble, bonds: &ContractLink<HumanAddr>, check_balance: Uint128) -> () {
+    let msg = bonds::QueryMsg::CheckBalance {  };
+
+    let query: bonds::QueryAnswer = chain.query(bonds.address.clone(), &msg).unwrap();
+
+    match query {
+        bonds::QueryAnswer::CheckBalance { balance } => {
+            assert_eq!(balance, check_balance)
+        }
+        _ => assert!(false),
+    }
+}
+
 pub fn query_opp_parameters(
     chain: &mut ContractEnsemble,
     bonds: &ContractLink<HumanAddr>,

--- a/packages/shade_protocol/src/contract_interfaces/bonds/errors.rs
+++ b/packages/shade_protocol/src/contract_interfaces/bonds/errors.rs
@@ -28,7 +28,6 @@ pub enum Error {
     IssuedPriceBelowMinimum,
     SlippageToleranceExceeded,
     Blacklisted,
-    IssuedAssetDeposit,
     NotTreasuryBond,
     NoBondsClaimable,
     NotAdmin,
@@ -96,9 +95,6 @@ impl CodeType for Error {
             }
             Error::Blacklisted => {
                 build_string("Cannot enter bond opportunity, sender address of {} is blacklisted", context)
-            }
-            Error::IssuedAssetDeposit => {
-                build_string("Cannot deposit using this contract's issued asset", context)
             }
             Error::NotTreasuryBond => {
                 build_string("Cannot perform function since this is not a treasury bond", context)
@@ -309,10 +305,6 @@ pub fn permit_revoked(user: &str) -> StdError {
 
 pub fn blacklisted(address: HumanAddr) -> StdError {
     DetailedError::from_code(BOND_TARGET, Error::Blacklisted, vec![address.as_str()]).to_error()
-}
-
-pub fn issued_asset_deposit() -> StdError {
-    DetailedError::from_code(BOND_TARGET, Error::IssuedAssetDeposit, vec![]).to_error()
 }
 
 pub fn not_treasury_bond() -> StdError {


### PR DESCRIPTION
Signed-off-by: Kyle Wahlberg <kyle.s.wahlberg@gmail.com>

<!-- NOTE: Listed items are examples and should be removed when making a PR -->

# Description
Removes error that blocked allowing SHD -> SHD bonds, or any other opportunity that wants to issue and accept the same asset. Tests were updated to reflect this capability and confirm that no deposit/receive loop occurs when the bonds contract sends itself the issued funds after the user has deposited.
